### PR TITLE
Add missing shape style alias to fix resource link error

### DIFF
--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,0 +1,21 @@
+<resources>
+    <!-- Shared shape appearance for rounded 12dp corners -->
+    <style name="Shape.Round12">
+        <item name="cornerFamily">rounded</item>
+        <item name="cornerSize">12dp</item>
+    </style>
+
+    <!-- Alias to satisfy views referencing @style/shape -->
+    <style name="shape" parent="@style/Shape.Round12" />
+
+    <style name="BottomNav_NoIndicator" parent="@style/Widget.Material3.NavigationBar.ActiveIndicator">
+        <!-- remove the default Material3 active indicator -->
+        <item name="android:color">@android:color/transparent</item>
+        <item name="android:background">@android:color/transparent</item>
+    </style>
+
+    <style name="BottomNavTextAppearance" parent="TextAppearance.Design.Tab">
+        <item name="android:textSize">12sp</item>
+        <item name="android:textColor">@color/white</item>
+    </style>
+</resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -6,42 +6,4 @@
     </style>
 
     <style name="Theme.Tesatyla" parent="Base.Theme.Tesatyla" />
-
-
-    <!-- res/values/styles.xml -->
-<!--    <style name="Royal.BottomNav.ActiveIndicator">-->
-
-<!--        &lt;!&ndash; ширина по содержимому &ndash;&gt;-->
-<!--&lt;!&ndash;        <item name="android:width">wrap_content</item>&ndash;&gt;-->
-<!--        <item name="android:height">32dp</item>-->
-
-<!--        &lt;!&ndash; внутренние отступы, чтобы капсула была чуть больше текста &ndash;&gt;-->
-<!--        <item name="android:paddingLeft">14dp</item>-->
-<!--        <item name="android:paddingRight">14dp</item>-->
-<!--        <item name="android:paddingTop">4dp</item>-->
-<!--        <item name="android:paddingBottom">4dp</item>-->
-
-<!--        &lt;!&ndash; скругление &ndash;&gt;-->
-<!--        <item name="shapeAppearanceSmallComponent">@style/Shape.Round12</item>-->
-
-<!--        &lt;!&ndash; градиентный фон как в макете &ndash;&gt;-->
-<!--        <item name="android:background">@drawable/bnv_active_bg</item>-->
-<!--    </style>-->
-
-    <style name="BottomNav_NoIndicator" parent="">
-        <!-- remove the default Material3 active indicator -->
-        <item name="android:color">@android:color/transparent</item>
-        <item name="android:background">@android:color/transparent</item>
-    </style>
-
-    <style name="Shape.Round12">
-        <item name="cornerFamily">rounded</item>
-        <item name="cornerSize">12dp</item>
-    </style>
-
-    <style name="BottomNavTextAppearance" parent="TextAppearance.Design.Tab">
-        <item name="android:textSize">12sp</item>
-        <item name="android:textColor">@color/white</item>
-    </style>
-
 </resources>


### PR DESCRIPTION
## Summary
- add a dedicated styles.xml with the shared bottom navigation styles and a shape alias used by resource references
- trim themes.xml back to the theme definitions now that the styles live in the separate file

## Testing
- not run (Android SDK unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68dd30e4bc10832aad9195c1345984af