### PR TITLE
Refresh onboarding carousel layout

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -64,6 +64,8 @@ dependencies {
     implementation(libs.hilt.android)
     kapt(libs.hilt.compiler)
     implementation ("androidx.compose.material3:material3:1.0.0")
+    implementation("androidx.viewpager2:viewpager2:1.0.0")
+    implementation("androidx.cardview:cardview:1.0.0")
 
 
 }

--- a/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/onboarding/OnBoardingFragment.kt
+++ b/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/onboarding/OnBoardingFragment.kt
@@ -4,22 +4,50 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.LinearLayout
+import androidx.appcompat.widget.AppCompatImageView
+import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.navOptions
-
+import androidx.recyclerview.widget.RecyclerView
+import androidx.viewpager2.widget.CompositePageTransformer
+import androidx.viewpager2.widget.MarginPageTransformer
+import androidx.viewpager2.widget.ViewPager2
 import sr.otaryp.tesatyla.R
 import sr.otaryp.tesatyla.data.preferences.LaunchPreferences
 import sr.otaryp.tesatyla.databinding.FragmentOnBoardingBinding
+import kotlin.math.abs
 
 class OnBoardingFragment : Fragment() {
 
     private var _binding: FragmentOnBoardingBinding? = null
     private val binding get() = _binding!!
+    private var pageChangeCallback: ViewPager2.OnPageChangeCallback? = null
+
+    private val slides by lazy {
+        listOf(
+            OnboardingSlide(
+                titleRes = R.string.onboarding_daily_learning_title,
+                descriptionRes = R.string.onboarding_daily_learning_description,
+                illustrationRes = R.drawable.ic_onboarding_daily_learning
+            ),
+            OnboardingSlide(
+                titleRes = R.string.onboarding_quick_tips_title,
+                descriptionRes = R.string.onboarding_quick_tips_description,
+                illustrationRes = R.drawable.ic_onboarding_quick_tips
+            ),
+            OnboardingSlide(
+                titleRes = R.string.onboarding_progress_title,
+                descriptionRes = R.string.onboarding_progress_description,
+                illustrationRes = R.drawable.ic_onboarding_progress
+            )
+        )
+    }
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
-        savedInstanceState: Bundle?
+        savedInstanceState: Bundle?,
     ): View {
         _binding = FragmentOnBoardingBinding.inflate(inflater, container, false)
         return binding.root
@@ -27,6 +55,21 @@ class OnBoardingFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        setupViewPager()
+        setupIndicators()
+        updateEnterButtonVisibility(0)
+
+        pageChangeCallback = object : ViewPager2.OnPageChangeCallback() {
+            override fun onPageSelected(position: Int) {
+                super.onPageSelected(position)
+                updateEnterButtonVisibility(position)
+                updateIndicators(position)
+            }
+        }.also { callback ->
+            binding.viewPagerOnboarding.registerOnPageChangeCallback(callback)
+        }
+
         binding.btnEnterKingdom.setOnClickListener {
             LaunchPreferences.setOnboardingComplete(requireContext())
             val options = navOptions {
@@ -38,7 +81,71 @@ class OnBoardingFragment : Fragment() {
         }
     }
 
+    private fun setupViewPager() {
+        val sidePadding = resources.getDimensionPixelSize(R.dimen.onboarding_viewpager_side_padding)
+        val pageMargin = resources.getDimensionPixelSize(R.dimen.onboarding_viewpager_page_margin)
+
+        binding.viewPagerOnboarding.apply {
+            adapter = OnboardingPagerAdapter(slides)
+            offscreenPageLimit = slides.size
+            clipToPadding = false
+            clipChildren = false
+            setPadding(sidePadding, 0, sidePadding, 0)
+            (getChildAt(0) as? RecyclerView)?.overScrollMode = RecyclerView.OVER_SCROLL_NEVER
+
+            val transformer = CompositePageTransformer().apply {
+                addTransformer(MarginPageTransformer(pageMargin))
+                addTransformer { page, position ->
+                    val ratio = 1 - abs(position)
+                    val scale = 0.9f + (ratio * 0.1f)
+                    page.scaleY = scale
+                    page.scaleX = scale
+                    page.alpha = 0.6f + (ratio * 0.4f)
+                }
+            }
+
+            setPageTransformer(transformer)
+        }
+    }
+
+    private fun setupIndicators() {
+        val indicatorSize = resources.getDimensionPixelSize(R.dimen.onboarding_indicator_size)
+        val indicatorMargin = resources.getDimensionPixelSize(R.dimen.onboarding_indicator_margin)
+
+        binding.layoutIndicators.removeAllViews()
+        repeat(slides.size) {
+            val indicator = AppCompatImageView(requireContext()).apply {
+                setImageResource(R.drawable.bg_onboarding_indicator_inactive)
+                layoutParams = LinearLayout.LayoutParams(indicatorSize, indicatorSize).apply {
+                    setMargins(indicatorMargin, 0, indicatorMargin, 0)
+                }
+            }
+            binding.layoutIndicators.addView(indicator)
+        }
+
+        updateIndicators(0)
+    }
+
+    private fun updateIndicators(position: Int) {
+        val indicatorCount = binding.layoutIndicators.childCount
+        for (index in 0 until indicatorCount) {
+            val indicator = binding.layoutIndicators.getChildAt(index) as? AppCompatImageView
+            indicator?.setImageResource(
+                if (index == position) R.drawable.bg_onboarding_indicator_active
+                else R.drawable.bg_onboarding_indicator_inactive
+            )
+        }
+    }
+
+    private fun updateEnterButtonVisibility(position: Int) {
+        binding.btnEnterKingdom.isVisible = position == slides.lastIndex
+    }
+
     override fun onDestroyView() {
+        pageChangeCallback?.let { binding.viewPagerOnboarding.unregisterOnPageChangeCallback(it) }
+        binding.viewPagerOnboarding.adapter = null
+        binding.layoutIndicators.removeAllViews()
+        pageChangeCallback = null
         _binding = null
         super.onDestroyView()
     }

--- a/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/onboarding/OnboardingPagerAdapter.kt
+++ b/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/onboarding/OnboardingPagerAdapter.kt
@@ -1,0 +1,37 @@
+package sr.otaryp.tesatyla.presentation.ui.onboarding
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import sr.otaryp.tesatyla.databinding.ItemOnboardingSlideBinding
+
+class OnboardingPagerAdapter(
+    private val slides: List<OnboardingSlide>
+) : RecyclerView.Adapter<OnboardingPagerAdapter.SlideViewHolder>() {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): SlideViewHolder {
+        val binding = ItemOnboardingSlideBinding.inflate(
+            LayoutInflater.from(parent.context),
+            parent,
+            false
+        )
+        return SlideViewHolder(binding)
+    }
+
+    override fun onBindViewHolder(holder: SlideViewHolder, position: Int) {
+        holder.bind(slides[position])
+    }
+
+    override fun getItemCount(): Int = slides.size
+
+    inner class SlideViewHolder(
+        private val binding: ItemOnboardingSlideBinding
+    ) : RecyclerView.ViewHolder(binding.root) {
+
+        fun bind(slide: OnboardingSlide) {
+            binding.textTitle.setText(slide.titleRes)
+            binding.textDescription.setText(slide.descriptionRes)
+            binding.imageIllustration.setImageResource(slide.illustrationRes)
+        }
+    }
+}

--- a/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/onboarding/OnboardingSlide.kt
+++ b/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/onboarding/OnboardingSlide.kt
@@ -1,0 +1,10 @@
+package sr.otaryp.tesatyla.presentation.ui.onboarding
+
+import androidx.annotation.DrawableRes
+import androidx.annotation.StringRes
+
+data class OnboardingSlide(
+    @StringRes val titleRes: Int,
+    @StringRes val descriptionRes: Int,
+    @DrawableRes val illustrationRes: Int
+)

--- a/app/src/main/res/drawable/bg_onboarding_card.xml
+++ b/app/src/main/res/drawable/bg_onboarding_card.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <corners android:radius="32dp" />
+    <gradient
+        android:angle="90"
+        android:endColor="#FFF9E6"
+        android:startColor="#F5E0A3" />
+    <padding
+        android:bottom="4dp"
+        android:left="4dp"
+        android:right="4dp"
+        android:top="4dp" />
+</shape>

--- a/app/src/main/res/drawable/bg_onboarding_illustration_circle.xml
+++ b/app/src/main/res/drawable/bg_onboarding_illustration_circle.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="oval">
+    <size android:width="200dp" android:height="200dp" />
+    <gradient
+        android:angle="135"
+        android:endColor="#FCEBC4"
+        android:startColor="#F9D67D" />
+</shape>

--- a/app/src/main/res/drawable/bg_onboarding_indicator_active.xml
+++ b/app/src/main/res/drawable/bg_onboarding_indicator_active.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <corners android:radius="8dp" />
+    <solid android:color="#FFE08A" />
+</shape>

--- a/app/src/main/res/drawable/bg_onboarding_indicator_inactive.xml
+++ b/app/src/main/res/drawable/bg_onboarding_indicator_inactive.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <corners android:radius="8dp" />
+    <solid android:color="#ffffff" />
+    <alpha android:value="0.45" />
+</shape>

--- a/app/src/main/res/drawable/ic_onboarding_daily_learning.xml
+++ b/app/src/main/res/drawable/ic_onboarding_daily_learning.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="200dp"
+    android:height="200dp"
+    android:viewportWidth="200"
+    android:viewportHeight="200">
+    <path
+        android:fillColor="#FDE7C6"
+        android:pathData="M32,40h136a12,12 0 0 1 12,12v96a12,12 0 0 1 -12,12H32a12,12 0 0 1 -12,-12V52a12,12 0 0 1 12,-12z" />
+    <path
+        android:fillColor="#E0C299"
+        android:pathData="M20,56h160v12a12,12 0 0 1 -12,12H32a12,12 0 0 1 -12,-12z" />
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M44,80h112v8H44z" />
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M44,96h112v8H44z" />
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M44,112h80v8h-80z" />
+    <path
+        android:fillColor="#D4AF37"
+        android:pathData="M60,134l12,-22 12,18 12,-26 12,26 12,-18 12,22z" />
+    <path
+        android:fillColor="#FAD675"
+        android:pathData="M60,146h84v10h-84z" />
+    <path
+        android:fillColor="#FFE38F"
+        android:pathData="M48,68a5,5 0 1,1 0.1,0z" />
+    <path
+        android:fillColor="#FFE38F"
+        android:pathData="M90,60a5,5 0 1,1 0.1,0z" />
+    <path
+        android:fillColor="#FFE38F"
+        android:pathData="M132,68a5,5 0 1,1 0.1,0z" />
+</vector>

--- a/app/src/main/res/drawable/ic_onboarding_progress.xml
+++ b/app/src/main/res/drawable/ic_onboarding_progress.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="200dp"
+    android:height="200dp"
+    android:viewportWidth="200"
+    android:viewportHeight="200">
+    <path
+        android:fillColor="#E0D7FF"
+        android:pathData="M40,150h120a12,12 0 0 1 12,12v10H28v-10a12,12 0 0 1 12,-12z" />
+    <path
+        android:fillColor="#B9A6FF"
+        android:pathData="M40,150h120a12,12 0 0 1 12,12v4H28v-4a12,12 0 0 1 12,-12z" />
+    <path
+        android:fillColor="#D4AF37"
+        android:pathData="M56,128h88l-12,22H68z" />
+    <path
+        android:fillColor="#F9DD7A"
+        android:pathData="M64,66l12,24 14,-20 14,20 12,-24 14,24 10,-16 10,48H44l10,-48 10,16z" />
+    <path
+        android:fillColor="#FFE388"
+        android:pathData="M98,64a10,10 0 1,1 0.1,0z" />
+    <path
+        android:fillColor="#FFF5C4"
+        android:pathData="M60,108h80v8h-80z" />
+    <path
+        android:fillColor="#D1C4E9"
+        android:pathData="M32,162h136v12H32z" />
+</vector>

--- a/app/src/main/res/drawable/ic_onboarding_quick_tips.xml
+++ b/app/src/main/res/drawable/ic_onboarding_quick_tips.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="200dp"
+    android:height="200dp"
+    android:viewportWidth="200"
+    android:viewportHeight="200">
+    <path
+        android:fillColor="#F5E1C8"
+        android:pathData="M30,46h100a14,14 0 0 1 14,14v60a14,14 0 0 1 -14,14H30a14,14 0 0 1 -14,-14V60a14,14 0 0 1 14,-14z" />
+    <path
+        android:fillColor="#DFC29F"
+        android:pathData="M30,46a14,14 0 0 0 -14,14v12h128V60a14,14 0 0 0 -14,-14z" />
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M32,82h96v10h-96z" />
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M32,102h76v10h-76z" />
+    <path
+        android:fillColor="#F5E1C8"
+        android:pathData="M134,66h36a12,12 0 0 1 12,12v36a12,12 0 0 1 -12,12h-36z" />
+    <path
+        android:fillColor="#DFC29F"
+        android:pathData="M134,66h36a12,12 0 0 1 12,12v8h-48z" />
+    <path
+        android:fillColor="#FFD54F"
+        android:pathData="M76,34l6,18h18l-15,10 6,18 -15,-10 -15,10 6,-18 -15,-10h18z" />
+    <path
+        android:fillColor="#FFE082"
+        android:pathData="M160,52l4,10h10l-8,6 3,10 -9,-6 -9,6 3,-10 -8,-6h10z" />
+    <path
+        android:fillColor="#FFE082"
+        android:pathData="M148,130l3,8h8l-6,4 2,8 -7,-5 -7,5 2,-8 -6,-4h8z" />
+</vector>

--- a/app/src/main/res/layout/fragment_on_boarding.xml
+++ b/app/src/main/res/layout/fragment_on_boarding.xml
@@ -1,78 +1,89 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@drawable/bg_splash"
+    android:paddingHorizontal="24dp"
     tools:context=".presentation.ui.onboarding.OnBoardingFragment">
 
-    <FrameLayout
-        android:layout_width="match_parent"
-        android:layout_height="230dp"
-        android:layout_gravity="bottom"
-        android:layout_marginBottom="30dp"
-        android:layout_marginHorizontal="40dp"
-        android:orientation="vertical">
+    <TextView
+        android:id="@+id/textOnboardingHeading"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="48dp"
+        android:fontFamily="sans-serif-medium"
+        android:letterSpacing="0.02"
+        android:text="@string/onboarding_heading"
+        android:textColor="#F9F3D7"
+        android:textSize="28sp"
+        android:textStyle="bold"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
-        <ImageView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginBottom="30dp"
-            android:background="@drawable/paper"/>
-        <FrameLayout
-            android:layout_width="match_parent"
-            android:padding="15dp"
-            android:layout_marginTop="10dp"
-            android:layout_height="wrap_content">
+    <TextView
+        android:id="@+id/textOnboardingSubheading"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="12dp"
+        android:lineSpacingExtra="4dp"
+        android:text="@string/onboarding_subheading"
+        android:textColor="#F9E7B7"
+        android:textSize="16sp"
+        android:textStyle="normal"
+        app:layout_constraintEnd_toEndOf="@id/textOnboardingHeading"
+        app:layout_constraintStart_toStartOf="@id/textOnboardingHeading"
+        app:layout_constraintTop_toBottomOf="@id/textOnboardingHeading" />
 
+    <androidx.viewpager2.widget.ViewPager2
+        android:id="@+id/viewPagerOnboarding"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:layout_marginTop="32dp"
+        android:layout_marginBottom="24dp"
+        android:clipChildren="false"
+        android:clipToPadding="false"
+        android:overScrollMode="never"
+        app:layout_constraintBottom_toTopOf="@id/layoutIndicators"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/textOnboardingSubheading"
+        tools:listitem="@layout/item_onboarding_slide" />
 
-        <LinearLayout
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="10dp"
-            android:layout_gravity="center|top"
-            android:orientation="vertical">
+    <LinearLayout
+        android:id="@+id/layoutIndicators"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:orientation="horizontal"
+        android:paddingVertical="4dp"
+        app:layout_constraintBottom_toTopOf="@id/btnEnterKingdom"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/viewPagerOnboarding" />
 
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:gravity="center"
-                android:paddingTop="10dp"
-                android:paddingStart="10dp"
-                android:text="Build Your Royal Skills Every Day"
-                android:textSize="25sp" />
+    <androidx.appcompat.widget.AppCompatButton
+        android:id="@+id/btnEnterKingdom"
+        style="@style/Widget.AppCompat.Button"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="36dp"
+        android:background="@drawable/btn_enter_kingdom"
+        android:includeFontPadding="false"
+        android:letterSpacing="0.03"
+        android:minHeight="0dp"
+        android:minWidth="0dp"
+        android:paddingHorizontal="28dp"
+        android:paddingVertical="14dp"
+        android:text="@string/onboarding_enter_kingdom"
+        android:textAllCaps="true"
+        android:textColor="#FFE08A"
+        android:textSize="18sp"
+        android:textStyle="bold"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
 
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:gravity="center"
-                android:paddingStart="5dp"
-                android:layout_marginTop="5dp"
-                android:text="Every step strengthens discipline, unveils hidden knowledge, and fills the crown with the precious gems of achievements."
-                android:textSize="14sp" />
-
-        </LinearLayout>
-        </FrameLayout>
-
-
-        <androidx.appcompat.widget.AppCompatButton
-            android:id="@+id/btnEnterKingdom"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:background="@drawable/btn_enter_kingdom"
-            android:paddingHorizontal="28dp"
-            android:paddingVertical="14dp"
-            android:minWidth="0dp"
-            android:layout_gravity="bottom|end"
-            android:minHeight="0dp"
-            android:includeFontPadding="false"
-            android:text="ENTER THE KINGDOM"
-            android:textAllCaps="true"
-            android:textStyle="bold"
-            android:textSize="18sp"
-            android:letterSpacing="0.03"
-            android:textColor="#FFE08A" />
-
-    </FrameLayout>
-
-</FrameLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/item_onboarding_slide.xml
+++ b/app/src/main/res/layout/item_onboarding_slide.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <androidx.cardview.widget.CardView
+        android:id="@+id/cardBackground"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:layout_marginHorizontal="8dp"
+        android:layout_marginBottom="8dp"
+        android:layout_marginTop="8dp"
+        app:cardBackgroundColor="@android:color/transparent"
+        app:cardCornerRadius="32dp"
+        app:cardElevation="0dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:background="@drawable/bg_onboarding_card"
+            android:orientation="vertical"
+            android:paddingHorizontal="28dp"
+            android:paddingTop="32dp"
+            android:paddingBottom="36dp">
+
+            <FrameLayout
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_horizontal"
+                android:background="@drawable/bg_onboarding_illustration_circle"
+                android:padding="20dp">
+
+                <ImageView
+                    android:id="@+id/imageIllustration"
+                    android:layout_width="140dp"
+                    android:layout_height="140dp"
+                    android:contentDescription="@null"
+                    android:scaleType="centerInside" />
+            </FrameLayout>
+
+            <TextView
+                android:id="@+id/textTitle"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="24dp"
+                android:fontFamily="sans-serif-medium"
+                android:gravity="center"
+                android:letterSpacing="0.02"
+                android:textColor="#3B2B1C"
+                android:textSize="22sp"
+                android:textStyle="bold" />
+
+            <TextView
+                android:id="@+id/textDescription"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="12dp"
+                android:gravity="center"
+                android:lineSpacingExtra="6dp"
+                android:textColor="#5B4632"
+                android:textSize="15sp" />
+        </LinearLayout>
+    </androidx.cardview.widget.CardView>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="onboarding_viewpager_side_padding">48dp</dimen>
+    <dimen name="onboarding_viewpager_page_margin">16dp</dimen>
+    <dimen name="onboarding_indicator_size">16dp</dimen>
+    <dimen name="onboarding_indicator_margin">6dp</dimen>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,4 +2,13 @@
     <string name="app_name">tesatyla</string>
     <string name="splash_loading_message">Preparing your royal journey...</string>
     <string name="hello_blank_fragment">Hello blank fragment</string>
+    <string name="onboarding_daily_learning_title">Train a Little Every Day</string>
+    <string name="onboarding_daily_learning_description">Each royal step strengthens your discipline. Even a few minutes daily bring you closer to mastery.</string>
+    <string name="onboarding_quick_tips_title">Quick Pieces of Wisdom</string>
+    <string name="onboarding_quick_tips_description">Practical royal advice you can apply instantly. Short lessons, great victories.</string>
+    <string name="onboarding_progress_title">Build Your Kingdom of Skills</string>
+    <string name="onboarding_progress_description">Each completed lesson is a jewel in your crown. Watch your royal achievements grow brighter.</string>
+    <string name="onboarding_enter_kingdom">Enter the Kingdom</string>
+    <string name="onboarding_heading">Welcome to the Royal Academy</string>
+    <string name="onboarding_subheading">Discover daily lessons, swift wisdom, and sparkling milestones as you master every royal skill.</string>
 </resources>


### PR DESCRIPTION
## Summary
- add a hero heading, spacing adjustments, and slide indicators to the onboarding fragment
- restyle each onboarding page with a gradient card, circular illustration backdrop, and centered copy
- animate the ViewPager carousel with side padding and scaling while keeping the CTA limited to the final slide

## Testing
- `./gradlew :app:lint --no-daemon --console=plain` *(fails: SDK location not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dd5721a768832a8b1200a686ccfdb9