### PR TITLE
Simplify onboarding view pager implementation

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -64,6 +64,5 @@ dependencies {
     implementation(libs.hilt.android)
     kapt(libs.hilt.compiler)
     implementation ("androidx.compose.material3:material3:1.0.0")
-
-
+    implementation("androidx.viewpager2:viewpager2:1.0.0")
 }

--- a/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/onboarding/OnBoardingFragment.kt
+++ b/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/onboarding/OnBoardingFragment.kt
@@ -4,10 +4,11 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.navOptions
-
+import androidx.viewpager2.widget.ViewPager2
 import sr.otaryp.tesatyla.R
 import sr.otaryp.tesatyla.data.preferences.LaunchPreferences
 import sr.otaryp.tesatyla.databinding.FragmentOnBoardingBinding
@@ -16,10 +17,29 @@ class OnBoardingFragment : Fragment() {
 
     private var _binding: FragmentOnBoardingBinding? = null
     private val binding get() = _binding!!
+    private var pageChangeCallback: ViewPager2.OnPageChangeCallback? = null
+
+    private val slides by lazy {
+        listOf(
+            OnboardingSlide(
+                titleRes = R.string.onboarding_daily_learning_title,
+                descriptionRes = R.string.onboarding_daily_learning_description
+            ),
+            OnboardingSlide(
+                titleRes = R.string.onboarding_quick_tips_title,
+                descriptionRes = R.string.onboarding_quick_tips_description
+            ),
+            OnboardingSlide(
+                titleRes = R.string.onboarding_progress_title,
+                descriptionRes = R.string.onboarding_progress_description
+            )
+        )
+    }
 
     override fun onCreateView(
-        inflater: LayoutInflater, container: ViewGroup?,
-        savedInstanceState: Bundle?
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
     ): View {
         _binding = FragmentOnBoardingBinding.inflate(inflater, container, false)
         return binding.root
@@ -27,6 +47,20 @@ class OnBoardingFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        binding.viewPagerOnboarding.adapter = OnboardingPagerAdapter(slides)
+
+        updateEnterButtonVisibility(0)
+
+        pageChangeCallback = object : ViewPager2.OnPageChangeCallback() {
+            override fun onPageSelected(position: Int) {
+                super.onPageSelected(position)
+                updateEnterButtonVisibility(position)
+            }
+        }.also { callback ->
+            binding.viewPagerOnboarding.registerOnPageChangeCallback(callback)
+        }
+
         binding.btnEnterKingdom.setOnClickListener {
             LaunchPreferences.setOnboardingComplete(requireContext())
             val options = navOptions {
@@ -38,7 +72,14 @@ class OnBoardingFragment : Fragment() {
         }
     }
 
+    private fun updateEnterButtonVisibility(position: Int) {
+        binding.btnEnterKingdom.isVisible = position == slides.lastIndex
+    }
+
     override fun onDestroyView() {
+        pageChangeCallback?.let { binding.viewPagerOnboarding.unregisterOnPageChangeCallback(it) }
+        binding.viewPagerOnboarding.adapter = null
+        pageChangeCallback = null
         _binding = null
         super.onDestroyView()
     }

--- a/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/onboarding/OnboardingPagerAdapter.kt
+++ b/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/onboarding/OnboardingPagerAdapter.kt
@@ -1,0 +1,36 @@
+package sr.otaryp.tesatyla.presentation.ui.onboarding
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import sr.otaryp.tesatyla.databinding.ItemOnboardingSlideBinding
+
+class OnboardingPagerAdapter(
+    private val slides: List<OnboardingSlide>,
+) : RecyclerView.Adapter<OnboardingPagerAdapter.SlideViewHolder>() {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): SlideViewHolder {
+        val binding = ItemOnboardingSlideBinding.inflate(
+            LayoutInflater.from(parent.context),
+            parent,
+            false
+        )
+        return SlideViewHolder(binding)
+    }
+
+    override fun onBindViewHolder(holder: SlideViewHolder, position: Int) {
+        holder.bind(slides[position])
+    }
+
+    override fun getItemCount(): Int = slides.size
+
+    class SlideViewHolder(
+        private val binding: ItemOnboardingSlideBinding,
+    ) : RecyclerView.ViewHolder(binding.root) {
+
+        fun bind(slide: OnboardingSlide) {
+            binding.textTitle.setText(slide.titleRes)
+            binding.textDescription.setText(slide.descriptionRes)
+        }
+    }
+}

--- a/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/onboarding/OnboardingSlide.kt
+++ b/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/onboarding/OnboardingSlide.kt
@@ -1,0 +1,8 @@
+package sr.otaryp.tesatyla.presentation.ui.onboarding
+
+import androidx.annotation.StringRes
+
+data class OnboardingSlide(
+    @StringRes val titleRes: Int,
+    @StringRes val descriptionRes: Int,
+)

--- a/app/src/main/res/layout/fragment_on_boarding.xml
+++ b/app/src/main/res/layout/fragment_on_boarding.xml
@@ -11,67 +11,42 @@
         android:layout_height="230dp"
         android:layout_gravity="bottom"
         android:layout_marginBottom="30dp"
-        android:layout_marginHorizontal="40dp"
-        android:orientation="vertical">
+        android:layout_marginHorizontal="40dp">
 
         <ImageView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginBottom="30dp"
-            android:background="@drawable/paper"/>
-        <FrameLayout
             android:layout_width="match_parent"
-            android:padding="15dp"
+            android:layout_height="match_parent"
+            android:background="@drawable/paper"
+            android:contentDescription="@null" />
+
+        <androidx.viewpager2.widget.ViewPager2
+            android:id="@+id/viewPagerOnboarding"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
             android:layout_marginTop="10dp"
-            android:layout_height="wrap_content">
-
-
-        <LinearLayout
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="10dp"
-            android:layout_gravity="center|top"
-            android:orientation="vertical">
-
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:gravity="center"
-                android:paddingTop="10dp"
-                android:paddingStart="10dp"
-                android:text="Build Your Royal Skills Every Day"
-                android:textSize="25sp" />
-
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:gravity="center"
-                android:paddingStart="5dp"
-                android:layout_marginTop="5dp"
-                android:text="Every step strengthens discipline, unveils hidden knowledge, and fills the crown with the precious gems of achievements."
-                android:textSize="14sp" />
-
-        </LinearLayout>
-        </FrameLayout>
-
+            android:clipToPadding="false"
+            android:overScrollMode="never"
+            android:padding="15dp"
+            tools:listitem="@layout/item_onboarding_slide" />
 
         <androidx.appcompat.widget.AppCompatButton
             android:id="@+id/btnEnterKingdom"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:layout_gravity="bottom|end"
             android:background="@drawable/btn_enter_kingdom"
+            android:includeFontPadding="false"
+            android:letterSpacing="0.03"
+            android:minHeight="0dp"
+            android:minWidth="0dp"
             android:paddingHorizontal="28dp"
             android:paddingVertical="14dp"
-            android:minWidth="0dp"
-            android:layout_gravity="bottom|end"
-            android:minHeight="0dp"
-            android:includeFontPadding="false"
-            android:text="ENTER THE KINGDOM"
+            android:text="@string/onboarding_enter_kingdom"
             android:textAllCaps="true"
-            android:textStyle="bold"
+            android:textColor="#FFE08A"
             android:textSize="18sp"
-            android:letterSpacing="0.03"
-            android:textColor="#FFE08A" />
+            android:textStyle="bold"
+            android:visibility="gone" />
 
     </FrameLayout>
 

--- a/app/src/main/res/layout/item_onboarding_slide.xml
+++ b/app/src/main/res/layout/item_onboarding_slide.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:gravity="center|top"
+        android:orientation="vertical"
+        android:paddingTop="10dp"
+        android:paddingStart="10dp"
+        android:paddingEnd="10dp">
+
+        <TextView
+            android:id="@+id/textTitle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            android:paddingStart="10dp"
+            android:paddingTop="10dp"
+            android:textSize="25sp"
+            android:textStyle="bold" />
+
+        <TextView
+            android:id="@+id/textDescription"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="5dp"
+            android:gravity="center"
+            android:paddingStart="5dp"
+            android:textSize="14sp" />
+
+    </LinearLayout>
+
+</FrameLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,4 +2,11 @@
     <string name="app_name">tesatyla</string>
     <string name="splash_loading_message">Preparing your royal journey...</string>
     <string name="hello_blank_fragment">Hello blank fragment</string>
+    <string name="onboarding_daily_learning_title">Train a Little Every Day</string>
+    <string name="onboarding_daily_learning_description">Each royal step strengthens your discipline. Even a few minutes daily bring you closer to mastery.</string>
+    <string name="onboarding_quick_tips_title">Quick Pieces of Wisdom</string>
+    <string name="onboarding_quick_tips_description">Practical royal advice you can apply instantly. Short lessons, great victories.</string>
+    <string name="onboarding_progress_title">Build Your Kingdom of Skills</string>
+    <string name="onboarding_progress_description">Each completed lesson is a jewel in your crown. Watch your royal achievements grow brighter.</string>
+    <string name="onboarding_enter_kingdom">Enter the Kingdom</string>
 </resources>


### PR DESCRIPTION
## Summary
- restore the original onboarding layout while hosting the ViewPager2 above the paper background and CTA button
- provide a lightweight slide adapter that swaps the title and description text per page and only reveals the "Enter the Kingdom" button on the last slide
- remove the unused gradient card assets, indicator resources, and CardView dependency introduced by the previous redesign

## Testing
- `./gradlew :app:lint --no-daemon --console=plain` *(fails: SDK location not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dd5721a768832a8b1200a686ccfdb9