### PR TITLE
Populate article screen with productivity content

### DIFF
--- a/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/article/ArticleFragment.kt
+++ b/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/article/ArticleFragment.kt
@@ -1,60 +1,93 @@
 package sr.otaryp.tesatyla.presentation.ui.article
 
 import android.os.Bundle
-import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import sr.otaryp.tesatyla.R
+import androidx.fragment.app.Fragment
+import sr.otaryp.tesatyla.databinding.FragmentArticleBinding
+import sr.otaryp.tesatyla.databinding.ItemArticleSummaryBinding
 
-// TODO: Rename parameter arguments, choose names that match
-// the fragment initialization parameters, e.g. ARG_ITEM_NUMBER
-private const val ARG_PARAM1 = "param1"
-private const val ARG_PARAM2 = "param2"
-
-/**
- * A simple [Fragment] subclass.
- * Use the [ArticleFragment.newInstance] factory method to
- * create an instance of this fragment.
- */
 class ArticleFragment : Fragment() {
-    // TODO: Rename and change types of parameters
-    private var param1: String? = null
-    private var param2: String? = null
 
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        arguments?.let {
-            param1 = it.getString(ARG_PARAM1)
-            param2 = it.getString(ARG_PARAM2)
+    private var _binding: FragmentArticleBinding? = null
+    private val binding get() = _binding!!
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = FragmentArticleBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        renderArticles()
+    }
+
+    private fun renderArticles() {
+        val articles = listOf(
+            Article(
+                title = "1. Why the Pomodoro Technique Works",
+                content = "The Pomodoro Technique is more than just a timer; it’s a structured way to train your brain to focus. Our attention naturally decreases after 20–30 minutes, and pushing beyond that often leads to fatigue and burnout. By splitting work into 25-minute intervals followed by 5-minute breaks, you create a rhythm that respects your brain’s limits. These micro-breaks help prevent decision fatigue, reduce eye strain, and keep your motivation high. Over time, using Pomodoro regularly improves your ability to concentrate for longer sessions. Interestingly, the act of starting a timer creates psychological accountability: it feels like a small commitment, which makes it easier to begin tasks you’ve been avoiding. Instead of thinking, “I must work for hours,” you only commit to 25 minutes. This small shift often eliminates procrastination. For maximum impact, pair the technique with clear task goals. Don’t just “work on the report”; decide which part of the report to finish in one Pomodoro. When you finish four intervals, reward yourself with a longer break. With practice, Pomodoro becomes a discipline tool, teaching your brain to enter deep work faster and stay there longer."
+            ),
+            Article(
+                title = "2. The Science of To-Do Lists",
+                content = "A to-do list may look simple, but it’s one of the most powerful tools for productivity. Psychologists call this effect the “Zeigarnik Effect”: our brain remembers unfinished tasks better than finished ones. That’s why you sometimes can’t relax — your mind is busy keeping track of what still needs to be done. Writing tasks down unloads your brain, reducing stress and freeing mental capacity. However, not all lists are effective. A common mistake is filling them with too many vague tasks, which leads to overwhelm. The key is clarity and priority. Break down large projects into smaller, actionable items. Instead of writing “Work on project,” write “Draft introduction” or “Review data.” Another strategy is to prioritize tasks daily. Identify the top three that will make the biggest impact and start with those. This ensures you’re not just busy, but productive. Research shows that completing tasks also gives a dopamine release, motivating you to keep going. By combining psychological relief with clear priorities, to-do lists transform from a set of reminders into a roadmap that keeps you moving steadily toward your goals."
+            ),
+            Article(
+                title = "3. How Distractions Hijack Your Brain",
+                content = "Every ping from your phone or glance at social media might seem harmless, but it triggers a powerful process in your brain. When distracted, your brain releases dopamine, the same chemical tied to pleasure and reward. This makes distractions addictive, as your brain craves that little “hit” of novelty. The problem is that switching tasks has a heavy cognitive cost. Studies show it takes 15–25 minutes to fully regain focus after a distraction. This constant switching lowers your productivity and increases stress. But there’s good news: awareness is the first defense. By identifying your biggest distractions, you can set boundaries. For digital distractions, turning off notifications or using “Do Not Disturb” mode can help. For physical ones, like noisy environments, noise-cancelling headphones or background music can create a focus bubble. Building habits like checking messages at specific times instead of constantly can also re-train your brain. Protecting your focus is not about strict discipline but about designing an environment where distractions have less power over you. When your attention is guarded, your work quality improves dramatically."
+            ),
+            Article(
+                title = "4. The Power of Time Blocking",
+                content = "Time blocking is a simple yet transformative technique. Instead of keeping a long list of tasks and jumping between them, you assign specific time slots to activities. This creates structure, reduces decision fatigue, and ensures that important work gets done. For example, you might block 9:00–11:00 for deep work, 11:00–12:00 for meetings, and 1:00–2:00 for emails. By doing this, you give every task a “home,” which reduces the stress of wondering when you’ll get to it. Time blocking also helps you see your day more realistically. Many people overestimate how much they can do, leading to frustration. Blocking forces you to confront the limits of your time and make better choices. Another benefit is creating balance. By scheduling rest, learning, and even hobbies, you prevent burnout. Famous thinkers like Benjamin Franklin and modern CEOs use time blocking because it ensures progress on long-term goals, not just daily fires. Over time, this method trains your brain to enter “focus mode” more quickly, since each block has a clear purpose. It’s not just about managing time, but about taking control of your attention and energy."
+            ),
+            Article(
+                title = "5. Why We Procrastinate — and How to Beat It",
+                content = "Procrastination is not simply laziness — it’s often an emotional reaction. When we face a task that feels too big, boring, or uncomfortable, our brain seeks immediate relief by avoiding it. This short-term escape gives temporary comfort but creates long-term stress. Psychologists explain procrastination as a fight between two systems in the brain: the limbic system, which seeks instant pleasure, and the prefrontal cortex, which plans long-term goals. The key to overcoming procrastination is lowering the “entry barrier.” Break tasks into the smallest possible steps, like opening a document or writing one sentence. This reduces the mental resistance and creates momentum. Another powerful method is the “5-minute rule”: promise yourself to work on a task for just 5 minutes. Often, starting dissolves the resistance and you continue naturally. Rewarding progress also helps rewire your brain. Instead of waiting for the whole project to finish, celebrate small wins along the way. Over time, you teach your brain that action, even small, feels better than avoidance. Procrastination may never disappear fully, but with the right tools, you can keep it under control and stay productive."
+            ),
+            Article(
+                title = "6. The Psychology of Goal Setting",
+                content = "Goals are more than wishes; they’re mental anchors that guide attention and action. Psychologists describe goals as “motivational maps” — they give direction, sustain effort, and help us measure progress. However, not all goals are equal. Vague goals like “be more productive” rarely work because they don’t provide clarity. Instead, effective goals are specific and measurable: “write 500 words today” or “finish three tasks before noon.” Another powerful concept is linking goals to personal values. When a goal aligns with what truly matters to you, motivation becomes stronger and longer-lasting. Breaking big goals into smaller milestones also prevents overwhelm. Each small step gives a sense of achievement, releasing dopamine, which reinforces the desire to continue. Writing goals down increases commitment and makes them harder to ignore. Finally, regular reflection is key: review your goals weekly to adjust and realign. Goals are not rigid rules but flexible guides. When used wisely, they turn your daily actions into consistent progress toward meaningful outcomes."
+            ),
+            Article(
+                title = "7. The Role of Rest in Productivity",
+                content = "In a culture that glorifies constant hustle, rest is often seen as wasted time. But neuroscience shows the opposite: rest is when the brain consolidates memories, restores energy, and generates creative insights. Sleep is the most obvious form of rest, but short breaks during the day are equally powerful. Studies show that people who take brief breaks during work maintain higher productivity than those who push through without stopping. Rest is also mental variety: stepping away from a task to take a walk or engage in light activity often sparks new ideas. Athletes understand this principle well — muscles grow stronger not during training but during recovery. The same applies to mental work: sustainable productivity requires cycles of effort and renewal. By planning rest intentionally, like scheduling micro-breaks or ensuring a full lunch break away from screens, you protect your long-term performance. Far from being wasted, rest is an investment. It ensures that when you work, you bring energy, focus, and creativity to the task at hand."
+            ),
+            Article(
+                title = "8. The Art of Single-Tasking",
+                content = "Multitasking is often praised, but research shows it dramatically lowers efficiency. The human brain isn’t wired to focus on two demanding tasks at once. Instead, it rapidly switches between them, losing time and energy with every switch. This constant context shifting reduces accuracy, increases stress, and makes tasks take longer. Single-tasking — focusing on one thing until completion — is a much more powerful approach. It allows your brain to fully engage, enter flow, and produce higher-quality results. Practicing single-tasking requires intentional effort in today’s distraction-filled world. Start by eliminating obvious interruptions: silence notifications, close unused tabs, and keep only the materials you need for the task. Then, set a clear intention: “For the next 30 minutes, I will only work on this report.” Over time, your ability to resist switching strengthens. Single-tasking also brings psychological benefits: finishing a task provides closure, boosting motivation and lowering stress. By choosing depth over speed, you may do fewer tasks in a day, but the impact and quality of your work will be far greater."
+            ),
+            Article(
+                title = "9. How Environment Shapes Focus",
+                content = "Your surroundings influence focus more than you think. A cluttered desk, noisy background, or uncomfortable chair can silently drain energy and reduce concentration. Cognitive science shows that environmental “noise,” whether physical or digital, competes for your brain’s limited attention. By shaping your workspace intentionally, you create conditions where focus comes naturally. Start with physical space: a clean, organized desk reduces mental clutter. Lighting also matters — natural light boosts alertness and mood, while dim spaces encourage fatigue. Sound plays a role too. Some thrive in silence, others with background noise or music without lyrics. The key is awareness: notice what environment helps you enter deep work and recreate it consistently. Digital environment matters as well. Unnecessary notifications, open apps, or constant emails act like invisible noise. Structuring your environment is not about perfection, but about reducing friction. When your space supports your goals, focus feels less like a struggle and more like a natural state."
+            ),
+            Article(
+                title = "10. The Hidden Cost of Busyness",
+                content = "In modern life, being “busy” is often mistaken for being productive. But constant activity doesn’t always equal meaningful progress. Psychologists call this the “action bias” — the tendency to stay in motion just to feel useful. The danger is that busyness can distract from high-value work. Answering emails all day feels active but rarely moves big projects forward. True productivity means making choices about where to direct your limited time and energy. This requires courage: saying no to some tasks, delegating others, and focusing on fewer but more impactful actions. Another hidden cost of busyness is stress. When your schedule is always full, your brain never has room to think strategically or recharge. The result is burnout and declining effectiveness. A healthier approach is to embrace intentional slowness: pause, step back, and ask, “Is what I’m doing moving me toward my goals?” Busyness may impress others, but clarity and focus build lasting results. Productivity is not about doing more — it’s about doing what matters most."
+            )
+        )
+
+        binding.articleContainer.removeAllViews()
+        val inflater = LayoutInflater.from(requireContext())
+        articles.forEach { article ->
+            val itemBinding = ItemArticleSummaryBinding.inflate(inflater, binding.articleContainer, false)
+            itemBinding.textArticleTitle.text = article.title
+            itemBinding.textArticleContent.text = article.content
+            binding.articleContainer.addView(itemBinding.root)
         }
     }
 
-    override fun onCreateView(
-        inflater: LayoutInflater, container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View? {
-        // Inflate the layout for this fragment
-        return inflater.inflate(R.layout.fragment_article, container, false)
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 
-    companion object {
-        /**
-         * Use this factory method to create a new instance of
-         * this fragment using the provided parameters.
-         *
-         * @param param1 Parameter 1.
-         * @param param2 Parameter 2.
-         * @return A new instance of fragment ArticleFragment.
-         */
-        // TODO: Rename and change types and number of parameters
-        @JvmStatic
-        fun newInstance(param1: String, param2: String) =
-            ArticleFragment().apply {
-                arguments = Bundle().apply {
-                    putString(ARG_PARAM1, param1)
-                    putString(ARG_PARAM2, param2)
-                }
-            }
-    }
+    private data class Article(
+        val title: String,
+        val content: String
+    )
 }

--- a/app/src/main/res/layout/fragment_article.xml
+++ b/app/src/main/res/layout/fragment_article.xml
@@ -4,143 +4,79 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@drawable/article_fragment_bg"
+    android:fillViewport="true"
     tools:context=".presentation.ui.article.ArticleFragment">
 
     <LinearLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
+        android:layout_height="wrap_content"
         android:orientation="vertical">
 
-
-
-    <FrameLayout
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:paddingTop="30dp">
-
-        <TextView
-            android:id="@+id/btnBack"
-            android:layout_width="wrap_content"
+        <FrameLayout
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginStart="20dp"
-            android:text="Back"
-            android:textColor="@color/white"
-            android:textSize="20sp" />
+            android:paddingTop="30dp"
+            android:paddingBottom="20dp">
 
-        <ImageView
-            android:layout_width="50dp"
-            android:layout_height="50dp"
-            android:layout_gravity="end"
-            android:layout_marginEnd="20dp"
-            android:src="@drawable/settings_bg" />
+            <TextView
+                android:id="@+id/btnBack"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="20dp"
+                android:text="Back"
+                android:textColor="@color/white"
+                android:textSize="20sp" />
 
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="bottom|center"
-            android:layout_marginTop="20dp"
-            android:layout_marginBottom="10dp"
-            android:gravity="center"
-            android:paddingTop="20dp"
-            android:text="Lesson 1:\nPomodoro trials"
-            android:textSize="25sp" />
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:layout_marginTop="24dp"
+                android:gravity="center"
+                android:paddingTop="8dp"
+                android:text="Productivity Articles"
+                android:textColor="@color/white"
+                android:textSize="26sp"
+                android:textStyle="bold" />
 
-
-    </FrameLayout>
+            <ImageView
+                android:layout_width="50dp"
+                android:layout_height="50dp"
+                android:layout_gravity="end"
+                android:layout_marginEnd="20dp"
+                android:src="@drawable/settings_bg" />
+        </FrameLayout>
 
         <View
             android:id="@+id/goldDivider"
             android:layout_width="match_parent"
             android:layout_height="2dp"
             android:layout_marginTop="10dp"
-            android:background="@drawable/gradient_view"
-           />
+            android:background="@drawable/gradient_view" />
 
         <EditText
             android:id="@+id/search_bar"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:hint="Search"
-            android:paddingStart="16dp"
-            android:fontFamily="@font/poppins_regular"
+            android:layout_marginHorizontal="30dp"
+            android:layout_marginTop="20dp"
+            android:layout_marginBottom="16dp"
+            android:background="@drawable/search_bar_background"
             android:drawablePadding="10dp"
             android:drawableStart="@drawable/search_ic"
-            android:paddingVertical="10dp"
-            android:layout_marginHorizontal="30dp"
+            android:fontFamily="@font/poppins_regular"
+            android:hint="Search"
+            android:paddingStart="16dp"
             android:paddingEnd="16dp"
-            android:textColor="#666666A1"
-            android:background="@drawable/search_bar_background"
-            android:layout_marginTop="16dp"
-            android:layout_marginBottom="16dp" />
+            android:paddingVertical="10dp"
+            android:textColor="#666666A1" />
 
-        <FrameLayout
+        <LinearLayout
+            android:id="@+id/articleContainer"
             android:layout_width="match_parent"
-            android:layout_height="185dp"
+            android:layout_height="wrap_content"
             android:layout_marginHorizontal="20dp"
-            android:layout_marginTop="10dp">
-
-            <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="160dp"
-                android:background="@drawable/list_with_quests"
-                android:padding="30dp"
-                android:orientation="horizontal">
-
-                <ImageView
-                    android:layout_width="100dp"
-                    android:layout_height="100dp"
-                    android:scaleType="fitEnd"
-                    android:src="@drawable/article_im1"/>
-
-
-                <LinearLayout
-                    android:layout_width="match_parent"
-                    android:orientation="vertical"
-                    android:layout_height="match_parent">
-
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_gravity="center"
-                    android:fontFamily="@font/inter_18pt_bold"
-                    android:gravity="center"
-                    android:maxLines="2"
-                    android:text="Why the Pomodoro Technique Works"
-                    android:textColor="#511300"
-                    android:textSize="15sp" />
-
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_gravity="center"
-                    android:gravity="center"
-                    android:maxLines="3"
-                    android:text="The Pomodoro Technique is more than just a timer; it’s a structured way to train your ..." />
-
-                </LinearLayout>
-
-            </LinearLayout>
-
-            <androidx.appcompat.widget.AppCompatButton
-                android:id="@+id/btnNextT2"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="bottom|end"
-                android:background="@drawable/btn_enter_kingdom1"
-                android:minWidth="160dp"
-                android:minHeight="0dp"
-                android:paddingHorizontal="30dp"
-                android:paddingVertical="14dp"
-                android:layout_marginEnd="20dp"
-                android:text="Continue"
-                android:textAllCaps="false"
-                android:textColor="#FFE08A"
-                android:textSize="18sp"
-                android:textStyle="bold" />
-        </FrameLayout>
-
-
+            android:layout_marginBottom="32dp"
+            android:orientation="vertical" />
     </LinearLayout>
-
-
 </ScrollView>

--- a/app/src/main/res/layout/item_article_summary.xml
+++ b/app/src/main/res/layout/item_article_summary.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginBottom="16dp"
+    android:background="@drawable/list_with_quests"
+    android:orientation="vertical"
+    android:padding="24dp">
+
+    <TextView
+        android:id="@+id/textArticleTitle"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:fontFamily="@font/inter_18pt_bold"
+        android:textColor="#511300"
+        android:textSize="18sp"
+        android:textStyle="bold" />
+
+    <TextView
+        android:id="@+id/textArticleContent"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="12dp"
+        android:fontFamily="@font/inter_18pt_regular"
+        android:textColor="#DCFFFFFF"
+        android:textSize="14sp" />
+</LinearLayout>


### PR DESCRIPTION
## Summary
- replace the placeholder ArticleFragment implementation with a view-binding driven list of articles
- refresh the article screen layout and add an item template to render the full productivity writeups provided

## Testing
- `./gradlew :app:assembleDebug` *(fails: SDK location not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dda274d874832ab958e8bb29fbad60