### PR TITLE
Implement inspirational home actions

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -58,6 +58,7 @@ dependencies {
     implementation(libs.kotlinx.coroutines.android)
     implementation(libs.navigation.fragment.ktx)
     implementation(libs.navigation.ui.ktx)
+    implementation("androidx.cardview:cardview:1.0.0")
     implementation(libs.room.runtime)
     implementation(libs.room.ktx)
     kapt(libs.room.compiler)

--- a/app/src/main/java/sr/otaryp/tesatyla/data/content/InspirationRepository.kt
+++ b/app/src/main/java/sr/otaryp/tesatyla/data/content/InspirationRepository.kt
@@ -1,0 +1,86 @@
+package sr.otaryp.tesatyla.data.content
+
+import java.util.Calendar
+
+object InspirationRepository {
+
+    data class Article(
+        val id: Int,
+        val title: String,
+        val content: String
+    )
+
+    private val articles = listOf(
+        Article(
+            id = 1,
+            title = "1. Why the Pomodoro Technique Works",
+            content = "The Pomodoro Technique is more than just a timer; it’s a structured way to train your brain to focus. Our attention naturally decreases after 20–30 minutes, and pushing beyond that often leads to fatigue and burnout. By splitting work into 25-minute intervals followed by 5-minute breaks, you create a rhythm that respects your brain’s limits. These micro-breaks help prevent decision fatigue, reduce eye strain, and keep your motivation high. Over time, using Pomodoro regularly improves your ability to concentrate for longer sessions. Interestingly, the act of starting a timer creates psychological accountability: it feels like a small commitment, which makes it easier to begin tasks you’ve been avoiding. Instead of thinking, “I must work for hours,” you only commit to 25 minutes. This small shift often eliminates procrastination. For maximum impact, pair the technique with clear task goals. Don’t just “work on the report”; decide which part of the report to finish in one Pomodoro. When you finish four intervals, reward yourself with a longer break. With practice, Pomodoro becomes a discipline tool, teaching your brain to enter deep work faster and stay there longer."
+        ),
+        Article(
+            id = 2,
+            title = "2. The Science of To-Do Lists",
+            content = "A to-do list may look simple, but it’s one of the most powerful tools for productivity. Psychologists call this effect the “Zeigarnik Effect”: our brain remembers unfinished tasks better than finished ones. That’s why you sometimes can’t relax — your mind is busy keeping track of what still needs to be done. Writing tasks down unloads your brain, reducing stress and freeing mental capacity. However, not all lists are effective. A common mistake is filling them with too many vague tasks, which leads to overwhelm. The key is clarity and priority. Break down large projects into smaller, actionable items. Instead of writing “Work on project,” write “Draft introduction” or “Review data.” Another strategy is to prioritize tasks daily. Identify the top three that will make the biggest impact and start with those. This ensures you’re not just busy, but productive. Research shows that completing tasks also gives a dopamine release, motivating you to keep going. By combining psychological relief with clear priorities, to-do lists transform from a set of reminders into a roadmap that keeps you moving steadily toward your goals."
+        ),
+        Article(
+            id = 3,
+            title = "3. How Distractions Hijack Your Brain",
+            content = "Every ping from your phone or glance at social media might seem harmless, but it triggers a powerful process in your brain. When distracted, your brain releases dopamine, the same chemical tied to pleasure and reward. This makes distractions addictive, as your brain craves that little “hit” of novelty. The problem is that switching tasks has a heavy cognitive cost. Studies show it takes 15–25 minutes to fully regain focus after a distraction. This constant switching lowers your productivity and increases stress. But there’s good news: awareness is the first defense. By identifying your biggest distractions, you can set boundaries. For digital distractions, turning off notifications or using “Do Not Disturb” mode can help. For physical ones, like noisy environments, noise-cancelling headphones or background music can create a focus bubble. Building habits like checking messages at specific times instead of constantly can also re-train your brain. Protecting your focus is not about strict discipline but about designing an environment where distractions have less power over you. When your attention is guarded, your work quality improves dramatically."
+        ),
+        Article(
+            id = 4,
+            title = "4. The Power of Time Blocking",
+            content = "Time blocking is a simple yet transformative technique. Instead of keeping a long list of tasks and jumping between them, you assign specific time slots to activities. This creates structure, reduces decision fatigue, and ensures that important work gets done. For example, you might block 9:00–11:00 for deep work, 11:00–12:00 for meetings, and 1:00–2:00 for emails. By doing this, you give every task a “home,” which reduces the stress of wondering when you’ll get to it. Time blocking also helps you see your day more realistically. Many people overestimate how much they can do, leading to frustration. Blocking forces you to confront the limits of your time and make better choices. Another benefit is creating balance. By scheduling rest, learning, and even hobbies, you prevent burnout. Famous thinkers like Benjamin Franklin and modern CEOs use time blocking because it ensures progress on long-term goals, not just daily fires. Over time, this method trains your brain to enter “focus mode” more quickly, since each block has a clear purpose. It’s not just about managing time, but about taking control of your attention and energy."
+        ),
+        Article(
+            id = 5,
+            title = "5. Why We Procrastinate — and How to Beat It",
+            content = "Procrastination is not simply laziness — it’s often an emotional reaction. When we face a task that feels too big, boring, or uncomfortable, our brain seeks immediate relief by avoiding it. This short-term escape gives temporary comfort but creates long-term stress. Psychologists explain procrastination as a fight between two systems in the brain: the limbic system, which seeks instant pleasure, and the prefrontal cortex, which plans long-term goals. The key to overcoming procrastination is lowering the “entry barrier.” Break tasks into the smallest possible steps, like opening a document or writing one sentence. This reduces the mental resistance and creates momentum. Another powerful method is the “5-minute rule”: promise yourself to work on a task for just 5 minutes. Often, starting dissolves the resistance and you continue naturally. Rewarding progress also helps rewire your brain. Instead of waiting for the whole project to finish, celebrate small wins along the way. Over time, you teach your brain that action, even small, feels better than avoidance. Procrastination may never disappear fully, but with the right tools, you can keep it under control and stay productive."
+        ),
+        Article(
+            id = 6,
+            title = "6. The Psychology of Goal Setting",
+            content = "Goals are more than wishes; they’re mental anchors that guide attention and action. Psychologists describe goals as “motivational maps” — they give direction, sustain effort, and help us measure progress. However, not all goals are equal. Vague goals like “be more productive” rarely work because they don’t provide clarity. Instead, effective goals are specific and measurable: “write 500 words today” or “finish three tasks before noon.” Another powerful concept is linking goals to personal values. When a goal aligns with what truly matters to you, motivation becomes stronger and longer-lasting. Breaking big goals into smaller milestones also prevents overwhelm. Each small step gives a sense of achievement, releasing dopamine, which reinforces the desire to continue. Writing goals down increases commitment and makes them harder to ignore. Finally, regular reflection is key: review your goals weekly to adjust and realign. Goals are not rigid rules but flexible guides. When used wisely, they turn your daily actions into consistent progress toward meaningful outcomes."
+        ),
+        Article(
+            id = 7,
+            title = "7. The Role of Rest in Productivity",
+            content = "In a culture that glorifies constant hustle, rest is often seen as wasted time. But neuroscience shows the opposite: rest is when the brain consolidates memories, restores energy, and generates creative insights. Sleep is the most obvious form of rest, but short breaks during the day are equally powerful. Studies show that people who take brief breaks during work maintain higher productivity than those who push through without stopping. Rest is also mental variety: stepping away from a task to take a walk or engage in light activity often sparks new ideas. Athletes understand this principle well — muscles grow stronger not during training but during recovery. The same applies to mental work: sustainable productivity requires cycles of effort and renewal. By planning rest intentionally, like scheduling micro-breaks or ensuring a full lunch break away from screens, you protect your long-term performance. Far from being wasted, rest is an investment. It ensures that when you work, you bring energy, focus, and creativity to the task at hand."
+        ),
+        Article(
+            id = 8,
+            title = "8. The Art of Single-Tasking",
+            content = "Multitasking is often praised, but research shows it dramatically lowers efficiency. The human brain isn’t wired to focus on two demanding tasks at once. Instead, it rapidly switches between them, losing time and energy with every switch. This constant context shifting reduces accuracy, increases stress, and makes tasks take longer. Single-tasking — focusing on one thing until completion — is a much more powerful approach. It allows your brain to fully engage, enter flow, and produce higher-quality results. Practicing single-tasking requires intentional effort in today’s distraction-filled world. Start by eliminating obvious interruptions: silence notifications, close unused tabs, and keep only the materials you need for the task. Then, set a clear intention: “For the next 30 minutes, I will only work on this report.” Over time, your ability to resist switching strengthens. Single-tasking also brings psychological benefits: finishing a task provides closure, boosting motivation and lowering stress. By choosing depth over speed, you may do fewer tasks in a day, but the impact and quality of your work will be far greater."
+        ),
+        Article(
+            id = 9,
+            title = "9. How Environment Shapes Focus",
+            content = "Your surroundings influence focus more than you think. A cluttered desk, noisy background, or uncomfortable chair can silently drain energy and reduce concentration. Cognitive science shows that environmental “noise,” whether physical or digital, competes for your brain’s limited attention. By shaping your workspace intentionally, you create conditions where focus comes naturally. Start with physical space: a clean, organized desk reduces mental clutter. Lighting also matters — natural light boosts alertness and mood, while dim spaces encourage fatigue. Sound plays a role too. Some thrive in silence, others with background noise or music without lyrics. The key is awareness: notice what environment helps you enter deep work and recreate it consistently. Digital environment matters as well. Unnecessary notifications, open apps, or constant emails act like invisible noise. Structuring your environment is not about perfection, but about reducing friction. When your space supports your goals, focus feels less like a struggle and more like a natural state."
+        ),
+        Article(
+            id = 10,
+            title = "10. The Hidden Cost of Busyness",
+            content = "In modern life, being “busy” is often mistaken for being productive. But constant activity doesn’t always equal meaningful progress. Psychologists call this the “action bias” — the tendency to stay in motion just to feel useful. The danger is that busyness can distract from high-value work. Answering emails all day feels active but rarely moves big projects forward. True productivity means making choices about where to direct your limited time and energy. This requires courage: saying no to some tasks, delegating others, and focusing on fewer but more impactful actions. Another hidden cost of busyness is stress. When your schedule is always full, your brain never has room to think strategically or recharge. The result is burnout and declining effectiveness. A healthier approach is to embrace intentional slowness: pause, step back, and ask, “Is what I’m doing moving me toward my goals?” Busyness may impress others, but clarity and focus build lasting results. Productivity is not about doing more — it’s about doing what matters most."
+        )
+    )
+
+    val dailyTips = listOf(
+        "Set your royal quest: choose 3 main goals for today and guard them well.",
+        "Train like a knight: 25 minutes of focused work, followed by a short rest to sharpen your sword.",
+        "Crown the important tasks first. Royal duties come before urgent whispers.",
+        "Banish one distraction from your realm — silence the messenger, close the scroll, guard your focus.",
+        "Prepare your royal scroll tonight — tomorrow’s path will be clear and noble.",
+        "Gather similar quests together — conquering them as a unit saves your strength.",
+        "Pause and reflect: every small victory makes your kingdom stronger."
+    )
+
+    fun getArticles(): List<Article> = articles
+
+    fun getArticleById(id: Int): Article? = articles.firstOrNull { it.id == id }
+
+    fun getRandomArticle(): Article = articles.random()
+
+    fun getTipIndexForToday(): Int {
+        val today = Calendar.getInstance().get(Calendar.DAY_OF_YEAR)
+        return (today - 1) % dailyTips.size
+    }
+}

--- a/app/src/main/java/sr/otaryp/tesatyla/data/preferences/LessonProgressPreferences.kt
+++ b/app/src/main/java/sr/otaryp/tesatyla/data/preferences/LessonProgressPreferences.kt
@@ -1,0 +1,41 @@
+package sr.otaryp.tesatyla.data.preferences
+
+import android.content.Context
+import androidx.core.content.edit
+
+data class LessonProgress(
+    val lessonId: Int,
+    val lessonTitle: String
+)
+
+object LessonProgressPreferences {
+
+    private const val PREFS_NAME = "lesson_progress"
+    private const val KEY_LESSON_ID = "lesson_id"
+    private const val KEY_LESSON_TITLE = "lesson_title"
+
+    fun getCurrentLesson(context: Context): LessonProgress? {
+        val sharedPreferences = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        val lessonId = sharedPreferences.getInt(KEY_LESSON_ID, -1)
+        val lessonTitle = sharedPreferences.getString(KEY_LESSON_TITLE, null)
+        return if (lessonId != -1 && !lessonTitle.isNullOrBlank()) {
+            LessonProgress(lessonId, lessonTitle)
+        } else {
+            null
+        }
+    }
+
+    fun setCurrentLesson(context: Context, lessonId: Int, lessonTitle: String) {
+        context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE).edit {
+            putInt(KEY_LESSON_ID, lessonId)
+            putString(KEY_LESSON_TITLE, lessonTitle)
+        }
+    }
+
+    fun clear(context: Context) {
+        context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE).edit {
+            remove(KEY_LESSON_ID)
+            remove(KEY_LESSON_TITLE)
+        }
+    }
+}

--- a/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/article/ArticleDetailFragment.kt
+++ b/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/article/ArticleDetailFragment.kt
@@ -1,60 +1,37 @@
 package sr.otaryp.tesatyla.presentation.ui.article
 
 import android.os.Bundle
-import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import sr.otaryp.tesatyla.R
+import androidx.fragment.app.Fragment
+import androidx.navigation.fragment.findNavController
+import androidx.navigation.fragment.navArgs
+import sr.otaryp.tesatyla.databinding.FragmentArticleDetailBinding
 
-// TODO: Rename parameter arguments, choose names that match
-// the fragment initialization parameters, e.g. ARG_ITEM_NUMBER
-private const val ARG_PARAM1 = "param1"
-private const val ARG_PARAM2 = "param2"
-
-/**
- * A simple [Fragment] subclass.
- * Use the [ArticleDetailFragment.newInstance] factory method to
- * create an instance of this fragment.
- */
 class ArticleDetailFragment : Fragment() {
-    // TODO: Rename and change types of parameters
-    private var param1: String? = null
-    private var param2: String? = null
 
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        arguments?.let {
-            param1 = it.getString(ARG_PARAM1)
-            param2 = it.getString(ARG_PARAM2)
-        }
-    }
+    private var _binding: FragmentArticleDetailBinding? = null
+    private val binding get() = _binding!!
+    private val args: ArticleDetailFragmentArgs by navArgs()
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
-    ): View? {
-        // Inflate the layout for this fragment
-        return inflater.inflate(R.layout.fragment_article_detail, container, false)
+    ): View {
+        _binding = FragmentArticleDetailBinding.inflate(inflater, container, false)
+        return binding.root
     }
 
-    companion object {
-        /**
-         * Use this factory method to create a new instance of
-         * this fragment using the provided parameters.
-         *
-         * @param param1 Parameter 1.
-         * @param param2 Parameter 2.
-         * @return A new instance of fragment ArticleDetailFragment.
-         */
-        // TODO: Rename and change types and number of parameters
-        @JvmStatic
-        fun newInstance(param1: String, param2: String) =
-            ArticleDetailFragment().apply {
-                arguments = Bundle().apply {
-                    putString(ARG_PARAM1, param1)
-                    putString(ARG_PARAM2, param2)
-                }
-            }
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        binding.textArticleTitle.text = args.articleTitle
+        binding.textArticleContent.text = args.articleContent
+        binding.btnBack.setOnClickListener { findNavController().popBackStack() }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 }

--- a/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/article/ArticleFragment.kt
+++ b/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/article/ArticleFragment.kt
@@ -5,6 +5,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import sr.otaryp.tesatyla.data.content.InspirationRepository
 import sr.otaryp.tesatyla.databinding.FragmentArticleBinding
 import sr.otaryp.tesatyla.databinding.ItemArticleSummaryBinding
 
@@ -28,48 +29,7 @@ class ArticleFragment : Fragment() {
     }
 
     private fun renderArticles() {
-        val articles = listOf(
-            Article(
-                title = "1. Why the Pomodoro Technique Works",
-                content = "The Pomodoro Technique is more than just a timer; it’s a structured way to train your brain to focus. Our attention naturally decreases after 20–30 minutes, and pushing beyond that often leads to fatigue and burnout. By splitting work into 25-minute intervals followed by 5-minute breaks, you create a rhythm that respects your brain’s limits. These micro-breaks help prevent decision fatigue, reduce eye strain, and keep your motivation high. Over time, using Pomodoro regularly improves your ability to concentrate for longer sessions. Interestingly, the act of starting a timer creates psychological accountability: it feels like a small commitment, which makes it easier to begin tasks you’ve been avoiding. Instead of thinking, “I must work for hours,” you only commit to 25 minutes. This small shift often eliminates procrastination. For maximum impact, pair the technique with clear task goals. Don’t just “work on the report”; decide which part of the report to finish in one Pomodoro. When you finish four intervals, reward yourself with a longer break. With practice, Pomodoro becomes a discipline tool, teaching your brain to enter deep work faster and stay there longer."
-            ),
-            Article(
-                title = "2. The Science of To-Do Lists",
-                content = "A to-do list may look simple, but it’s one of the most powerful tools for productivity. Psychologists call this effect the “Zeigarnik Effect”: our brain remembers unfinished tasks better than finished ones. That’s why you sometimes can’t relax — your mind is busy keeping track of what still needs to be done. Writing tasks down unloads your brain, reducing stress and freeing mental capacity. However, not all lists are effective. A common mistake is filling them with too many vague tasks, which leads to overwhelm. The key is clarity and priority. Break down large projects into smaller, actionable items. Instead of writing “Work on project,” write “Draft introduction” or “Review data.” Another strategy is to prioritize tasks daily. Identify the top three that will make the biggest impact and start with those. This ensures you’re not just busy, but productive. Research shows that completing tasks also gives a dopamine release, motivating you to keep going. By combining psychological relief with clear priorities, to-do lists transform from a set of reminders into a roadmap that keeps you moving steadily toward your goals."
-            ),
-            Article(
-                title = "3. How Distractions Hijack Your Brain",
-                content = "Every ping from your phone or glance at social media might seem harmless, but it triggers a powerful process in your brain. When distracted, your brain releases dopamine, the same chemical tied to pleasure and reward. This makes distractions addictive, as your brain craves that little “hit” of novelty. The problem is that switching tasks has a heavy cognitive cost. Studies show it takes 15–25 minutes to fully regain focus after a distraction. This constant switching lowers your productivity and increases stress. But there’s good news: awareness is the first defense. By identifying your biggest distractions, you can set boundaries. For digital distractions, turning off notifications or using “Do Not Disturb” mode can help. For physical ones, like noisy environments, noise-cancelling headphones or background music can create a focus bubble. Building habits like checking messages at specific times instead of constantly can also re-train your brain. Protecting your focus is not about strict discipline but about designing an environment where distractions have less power over you. When your attention is guarded, your work quality improves dramatically."
-            ),
-            Article(
-                title = "4. The Power of Time Blocking",
-                content = "Time blocking is a simple yet transformative technique. Instead of keeping a long list of tasks and jumping between them, you assign specific time slots to activities. This creates structure, reduces decision fatigue, and ensures that important work gets done. For example, you might block 9:00–11:00 for deep work, 11:00–12:00 for meetings, and 1:00–2:00 for emails. By doing this, you give every task a “home,” which reduces the stress of wondering when you’ll get to it. Time blocking also helps you see your day more realistically. Many people overestimate how much they can do, leading to frustration. Blocking forces you to confront the limits of your time and make better choices. Another benefit is creating balance. By scheduling rest, learning, and even hobbies, you prevent burnout. Famous thinkers like Benjamin Franklin and modern CEOs use time blocking because it ensures progress on long-term goals, not just daily fires. Over time, this method trains your brain to enter “focus mode” more quickly, since each block has a clear purpose. It’s not just about managing time, but about taking control of your attention and energy."
-            ),
-            Article(
-                title = "5. Why We Procrastinate — and How to Beat It",
-                content = "Procrastination is not simply laziness — it’s often an emotional reaction. When we face a task that feels too big, boring, or uncomfortable, our brain seeks immediate relief by avoiding it. This short-term escape gives temporary comfort but creates long-term stress. Psychologists explain procrastination as a fight between two systems in the brain: the limbic system, which seeks instant pleasure, and the prefrontal cortex, which plans long-term goals. The key to overcoming procrastination is lowering the “entry barrier.” Break tasks into the smallest possible steps, like opening a document or writing one sentence. This reduces the mental resistance and creates momentum. Another powerful method is the “5-minute rule”: promise yourself to work on a task for just 5 minutes. Often, starting dissolves the resistance and you continue naturally. Rewarding progress also helps rewire your brain. Instead of waiting for the whole project to finish, celebrate small wins along the way. Over time, you teach your brain that action, even small, feels better than avoidance. Procrastination may never disappear fully, but with the right tools, you can keep it under control and stay productive."
-            ),
-            Article(
-                title = "6. The Psychology of Goal Setting",
-                content = "Goals are more than wishes; they’re mental anchors that guide attention and action. Psychologists describe goals as “motivational maps” — they give direction, sustain effort, and help us measure progress. However, not all goals are equal. Vague goals like “be more productive” rarely work because they don’t provide clarity. Instead, effective goals are specific and measurable: “write 500 words today” or “finish three tasks before noon.” Another powerful concept is linking goals to personal values. When a goal aligns with what truly matters to you, motivation becomes stronger and longer-lasting. Breaking big goals into smaller milestones also prevents overwhelm. Each small step gives a sense of achievement, releasing dopamine, which reinforces the desire to continue. Writing goals down increases commitment and makes them harder to ignore. Finally, regular reflection is key: review your goals weekly to adjust and realign. Goals are not rigid rules but flexible guides. When used wisely, they turn your daily actions into consistent progress toward meaningful outcomes."
-            ),
-            Article(
-                title = "7. The Role of Rest in Productivity",
-                content = "In a culture that glorifies constant hustle, rest is often seen as wasted time. But neuroscience shows the opposite: rest is when the brain consolidates memories, restores energy, and generates creative insights. Sleep is the most obvious form of rest, but short breaks during the day are equally powerful. Studies show that people who take brief breaks during work maintain higher productivity than those who push through without stopping. Rest is also mental variety: stepping away from a task to take a walk or engage in light activity often sparks new ideas. Athletes understand this principle well — muscles grow stronger not during training but during recovery. The same applies to mental work: sustainable productivity requires cycles of effort and renewal. By planning rest intentionally, like scheduling micro-breaks or ensuring a full lunch break away from screens, you protect your long-term performance. Far from being wasted, rest is an investment. It ensures that when you work, you bring energy, focus, and creativity to the task at hand."
-            ),
-            Article(
-                title = "8. The Art of Single-Tasking",
-                content = "Multitasking is often praised, but research shows it dramatically lowers efficiency. The human brain isn’t wired to focus on two demanding tasks at once. Instead, it rapidly switches between them, losing time and energy with every switch. This constant context shifting reduces accuracy, increases stress, and makes tasks take longer. Single-tasking — focusing on one thing until completion — is a much more powerful approach. It allows your brain to fully engage, enter flow, and produce higher-quality results. Practicing single-tasking requires intentional effort in today’s distraction-filled world. Start by eliminating obvious interruptions: silence notifications, close unused tabs, and keep only the materials you need for the task. Then, set a clear intention: “For the next 30 minutes, I will only work on this report.” Over time, your ability to resist switching strengthens. Single-tasking also brings psychological benefits: finishing a task provides closure, boosting motivation and lowering stress. By choosing depth over speed, you may do fewer tasks in a day, but the impact and quality of your work will be far greater."
-            ),
-            Article(
-                title = "9. How Environment Shapes Focus",
-                content = "Your surroundings influence focus more than you think. A cluttered desk, noisy background, or uncomfortable chair can silently drain energy and reduce concentration. Cognitive science shows that environmental “noise,” whether physical or digital, competes for your brain’s limited attention. By shaping your workspace intentionally, you create conditions where focus comes naturally. Start with physical space: a clean, organized desk reduces mental clutter. Lighting also matters — natural light boosts alertness and mood, while dim spaces encourage fatigue. Sound plays a role too. Some thrive in silence, others with background noise or music without lyrics. The key is awareness: notice what environment helps you enter deep work and recreate it consistently. Digital environment matters as well. Unnecessary notifications, open apps, or constant emails act like invisible noise. Structuring your environment is not about perfection, but about reducing friction. When your space supports your goals, focus feels less like a struggle and more like a natural state."
-            ),
-            Article(
-                title = "10. The Hidden Cost of Busyness",
-                content = "In modern life, being “busy” is often mistaken for being productive. But constant activity doesn’t always equal meaningful progress. Psychologists call this the “action bias” — the tendency to stay in motion just to feel useful. The danger is that busyness can distract from high-value work. Answering emails all day feels active but rarely moves big projects forward. True productivity means making choices about where to direct your limited time and energy. This requires courage: saying no to some tasks, delegating others, and focusing on fewer but more impactful actions. Another hidden cost of busyness is stress. When your schedule is always full, your brain never has room to think strategically or recharge. The result is burnout and declining effectiveness. A healthier approach is to embrace intentional slowness: pause, step back, and ask, “Is what I’m doing moving me toward my goals?” Busyness may impress others, but clarity and focus build lasting results. Productivity is not about doing more — it’s about doing what matters most."
-            )
-        )
+        val articles = InspirationRepository.getArticles()
 
         binding.articleContainer.removeAllViews()
         val inflater = LayoutInflater.from(requireContext())
@@ -85,9 +45,4 @@ class ArticleFragment : Fragment() {
         super.onDestroyView()
         _binding = null
     }
-
-    private data class Article(
-        val title: String,
-        val content: String
-    )
 }

--- a/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/main/HomeFragment.kt
+++ b/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/main/HomeFragment.kt
@@ -1,28 +1,141 @@
 package sr.otaryp.tesatyla.presentation.ui.main
 
 import android.os.Bundle
-import androidx.fragment.app.Fragment
+import android.view.GestureDetector
 import android.view.LayoutInflater
+import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
+import androidx.appcompat.app.AlertDialog
+import androidx.core.view.GestureDetectorCompat
+import androidx.fragment.app.Fragment
+import androidx.navigation.fragment.findNavController
 import sr.otaryp.tesatyla.R
+import sr.otaryp.tesatyla.data.content.InspirationRepository
+import sr.otaryp.tesatyla.data.preferences.LessonProgressPreferences
+import sr.otaryp.tesatyla.databinding.DialogSetRoyalQuestBinding
 import sr.otaryp.tesatyla.databinding.FragmentHomeBinding
 
 class HomeFragment : Fragment() {
 
-    private lateinit var binding: FragmentHomeBinding
+    private var _binding: FragmentHomeBinding? = null
+    private val binding get() = _binding!!
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
-    ): View? {
-        binding = FragmentHomeBinding.inflate(inflater,container,false)
+    ): View {
+        _binding = FragmentHomeBinding.inflate(inflater, container, false)
         return binding.root
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-
+        renderContinueLessonState()
+        setupClickListeners()
     }
 
+    private fun renderContinueLessonState() {
+        val lessonProgress = LessonProgressPreferences.getCurrentLesson(requireContext())
+        val messageRes = if (lessonProgress != null) {
+            R.string.home_continue_card_in_progress
+        } else {
+            R.string.home_continue_card_start
+        }
+        binding.textContinueLessonMessage.setText(messageRes)
+    }
+
+    private fun setupClickListeners() {
+        binding.continueLesson.setOnClickListener {
+            val navController = findNavController()
+            val lessonProgress = LessonProgressPreferences.getCurrentLesson(requireContext())
+            if (lessonProgress != null) {
+                navController.navigate(R.id.action_nav_home_to_lessonDetailFragment)
+            } else {
+                navController.navigate(R.id.action_nav_home_to_nav_lessons)
+            }
+        }
+
+        binding.randomArticle.setOnClickListener {
+            val randomArticle = InspirationRepository.getRandomArticle()
+            val directions = HomeFragmentDirections.actionNavHomeToArticleDetailFragment(
+                articleTitle = randomArticle.title,
+                articleContent = randomArticle.content
+            )
+            findNavController().navigate(directions)
+        }
+
+        binding.dailyTip.setOnClickListener {
+            showDailyTipDialog()
+        }
+    }
+
+    private fun showDailyTipDialog() {
+        val dialogBinding = DialogSetRoyalQuestBinding.inflate(layoutInflater)
+        val tips = InspirationRepository.dailyTips
+        var currentIndex = InspirationRepository.getTipIndexForToday()
+
+        fun renderTip() {
+            val positionText = getString(
+                R.string.dialog_tip_position,
+                currentIndex + 1,
+                tips.size
+            )
+            dialogBinding.textTipContent.text = tips[currentIndex]
+            dialogBinding.textTipPosition.text = positionText
+        }
+
+        renderTip()
+
+        val dialog = AlertDialog.Builder(requireContext())
+            .setView(dialogBinding.root)
+            .setCancelable(true)
+            .create()
+
+        dialogBinding.buttonClose.setOnClickListener { dialog.dismiss() }
+        dialogBinding.buttonNext.setOnClickListener {
+            currentIndex = (currentIndex + 1) % tips.size
+            renderTip()
+        }
+
+        val gestureDetector = GestureDetectorCompat(requireContext(), object : GestureDetector.SimpleOnGestureListener() {
+            private val swipeThreshold = 100
+            private val swipeVelocityThreshold = 100
+
+            override fun onFling(
+                e1: MotionEvent?,
+                e2: MotionEvent?,
+                velocityX: Float,
+                velocityY: Float
+            ): Boolean {
+                if (e1 == null || e2 == null) return false
+                val diffX = e2.x - e1.x
+                val diffY = e2.y - e1.y
+                if (kotlin.math.abs(diffX) > kotlin.math.abs(diffY)) {
+                    if (kotlin.math.abs(diffX) > swipeThreshold && kotlin.math.abs(velocityX) > swipeVelocityThreshold) {
+                        if (diffX > 0) {
+                            currentIndex = if (currentIndex - 1 < 0) tips.lastIndex else currentIndex - 1
+                        } else {
+                            currentIndex = (currentIndex + 1) % tips.size
+                        }
+                        renderTip()
+                        return true
+                    }
+                }
+                return false
+            }
+        })
+
+        dialogBinding.tipContainer.setOnTouchListener { _, event ->
+            gestureDetector.onTouchEvent(event)
+            false
+        }
+
+        dialog.show()
+    }
 }

--- a/app/src/main/res/drawable/bg_tip_scroll.xml
+++ b/app/src/main/res/drawable/bg_tip_scroll.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <gradient
+        android:angle="90"
+        android:endColor="#FFF4DC"
+        android:startColor="#FFE9B4" />
+    <corners android:radius="24dp" />
+    <padding
+        android:bottom="12dp"
+        android:left="16dp"
+        android:right="16dp"
+        android:top="12dp" />
+    <stroke
+        android:width="2dp"
+        android:color="#D6B073" />
+</shape>

--- a/app/src/main/res/layout/dialog_set_royal_quest.xml
+++ b/app/src/main/res/layout/dialog_set_royal_quest.xml
@@ -1,61 +1,76 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content">
-
-    <ImageView
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:src="@drawable/dialog_bg" />
+    android:layout_height="wrap_content"
+    android:layout_margin="24dp"
+    android:background="@android:color/transparent"
+    app:cardBackgroundColor="@android:color/transparent"
+    app:cardCornerRadius="24dp"
+    app:cardUseCompatPadding="true">
 
     <LinearLayout
+        android:id="@+id/tipContainer"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_gravity="center"
-        android:gravity="center"
-        android:orientation="vertical">
+        android:background="@drawable/bg_tip_scroll"
+        android:orientation="vertical"
+        android:padding="24dp">
 
         <TextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="Set your royal quest:\nchoose 3 main goals\nfor today and guard\nthem well."
-            android:textColor="#511300"
-            android:textFontWeight="400"
-            android:fontFamily="@font/katibeh_regular"
-            android:textSize="30sp" />
-
-        <androidx.appcompat.widget.AppCompatButton
-            android:id="@+id/btnNextT"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="20dp"
-            android:background="@drawable/btn_enter_kingdom"
-            android:includeFontPadding="false"
-            android:minWidth="160dp"
-            android:minHeight="0dp"
-            android:paddingHorizontal="35dp"
-            android:paddingVertical="14dp"
-            android:text="Next tip"
-            android:textAllCaps="false"
-            android:textColor="#FFE08A"
+            android:text="@string/dialog_tip_title"
+            android:textColor="#5B3A1A"
             android:textSize="18sp"
             android:textStyle="bold" />
 
-        <androidx.appcompat.widget.AppCompatButton
-            android:id="@+id/btnGotIt"
+        <TextView
+            android:id="@+id/textTipPosition"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:background="@drawable/btn_enter_kingdom"
-            android:includeFontPadding="false"
-            android:minWidth="160dp"
-            android:minHeight="0dp"
-            android:layout_marginTop="20dp"
-            android:paddingHorizontal="35dp"
-            android:paddingVertical="14dp"
-            android:text="Got it"
-            android:textAllCaps="false"
-            android:textColor="#FFE08A"
-            android:textSize="18sp"
+            android:layout_marginTop="4dp"
+            android:textColor="#5B3A1A"
+            android:textSize="14sp"
             android:textStyle="bold" />
+
+        <TextView
+            android:id="@+id/textTipContent"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            android:textColor="#3B2711"
+            android:textSize="16sp" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:text="@string/dialog_tip_swipe_hint"
+            android:textColor="#7A5B33"
+            android:textSize="12sp" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="20dp"
+            android:gravity="end"
+            android:orientation="horizontal">
+
+            <Button
+                android:id="@+id/buttonClose"
+                style="@style/Widget.MaterialComponents.Button.TextButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/dialog_tip_close" />
+
+            <Button
+                android:id="@+id/buttonNext"
+                style="@style/Widget.MaterialComponents.Button"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="12dp"
+                android:text="@string/dialog_tip_next" />
+        </LinearLayout>
     </LinearLayout>
-</FrameLayout>
+</androidx.cardview.widget.CardView>

--- a/app/src/main/res/layout/fragment_article_detail.xml
+++ b/app/src/main/res/layout/fragment_article_detail.xml
@@ -8,13 +8,12 @@
 
     <LinearLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
+        android:layout_height="wrap_content"
         android:orientation="vertical">
-
 
         <FrameLayout
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
+            android:layout_height="wrap_content"
             android:paddingTop="30dp">
 
             <TextView
@@ -22,7 +21,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="20dp"
-                android:text="Back"
+                android:text="@string/article_back"
                 android:textColor="@color/white"
                 android:textSize="20sp" />
 
@@ -31,19 +30,23 @@
                 android:layout_height="50dp"
                 android:layout_gravity="end"
                 android:layout_marginEnd="20dp"
+                android:contentDescription="@null"
                 android:src="@drawable/settings_bg" />
 
             <TextView
+                android:id="@+id/textArticleTitle"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="bottom|center"
                 android:layout_marginTop="20dp"
                 android:layout_marginBottom="10dp"
                 android:gravity="center"
+                android:maxWidth="280dp"
                 android:paddingTop="20dp"
-                android:text="Learn the 25–5 Pomodoro structure"
-                android:textSize="25sp" />
-
+                android:textColor="@color/white"
+                android:textSize="25sp"
+                android:textStyle="bold"
+                tools:text="Learn the 25–5 Pomodoro structure" />
 
         </FrameLayout>
 
@@ -67,33 +70,37 @@
             <ImageView
                 android:layout_width="match_parent"
                 android:layout_height="150dp"
+                android:contentDescription="@null"
                 android:src="@drawable/list_shorter" />
 
             <ImageView
                 android:layout_width="200dp"
                 android:layout_height="200dp"
-                android:layout_marginStart="5dp"
                 android:layout_gravity="center|bottom"
+                android:layout_marginStart="5dp"
+                android:contentDescription="@null"
                 android:src="@drawable/article_im1" />
-
 
         </FrameLayout>
 
         <LinearLayout
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
+            android:layout_height="wrap_content"
             android:layout_marginHorizontal="25dp"
             android:layout_marginTop="10dp"
-            android:background="@drawable/steps_bg_im">
+            android:background="@drawable/steps_bg_im"
+            android:orientation="vertical">
 
             <TextView
+                android:id="@+id/textArticleContent"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:fontFamily="@font/inter_18pt_regular"
                 android:paddingHorizontal="20dp"
-                android:text=" Theory: The Pomodoro method divides work into cycles of 25 minutes of focused work followed by 5 minutes of rest. These short sprints allow the brain to recharge regularly, preventing fatigue and increasing concentration. Long, uninterrupted work sessions often reduce effectiveness over time.  Practice: Read about the Pomodoro cycle. Write down the structure somewhere visible: 25 minutes work → 5 minutes rest → repeat 4 times → then a longer break of 15–30 minutes."
-                android:textColor="#DCFFFFFF"
-                android:textSize="14sp" />
+                android:paddingVertical="20dp"
+                android:textSize="14sp"
+                tools:text="Theory: The Pomodoro method divides work into cycles..." />
+</ScrollView>
 
         </LinearLayout>
 

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -1,90 +1,46 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@drawable/home_bg"
-    android:orientation="vertical"
+    android:fillViewport="true"
     tools:context=".presentation.ui.main.HomeFragment">
 
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="horizontal"
-        android:padding="20dp">
-
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_weight="1"
-            android:text="Rise, Young Knight!\nYour quests await."
-            android:textSize="30sp" />
-
-        <ImageView
-            android:layout_width="60dp"
-            android:layout_height="53dp"
-            android:layout_gravity="center"
-            android:src="@drawable/settings_bg" />
-
-    </LinearLayout>
-
-    <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginHorizontal="20dp"
-        android:layout_marginTop="20dp"
         android:orientation="vertical">
 
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginBottom="10dp"
-            android:text="Continue Lesson"
-            android:textColor="#FBF990"
-            android:textSize="20sp" />
-
         <LinearLayout
-            android:id="@+id/continueLesson"
             android:layout_width="match_parent"
-            android:layout_height="130dp"
-            android:background="@drawable/bg_linear"
-            android:gravity="center_vertical"
+            android:layout_height="wrap_content"
             android:orientation="horizontal"
             android:padding="20dp">
 
-            <ImageView
-                android:layout_width="120dp"
-                android:layout_height="120dp"
-                android:src="@drawable/books" />
-
-            <LinearLayout
-                android:layout_width="wrap_content"
+            <TextView
+                android:id="@+id/textWelcome"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:layout_gravity="top"
-                android:layout_marginStart="20dp"
-                android:orientation="vertical">
+                android:layout_weight="1"
+                android:text="@string/home_welcome_message"
+                android:textColor="@color/white"
+                android:textSize="30sp"
+                android:textStyle="bold" />
 
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginBottom="15dp"
-                    android:text="Your Quest Continues"
-                    android:textColor="#FBF990"
-                    android:textSize="18sp" />
+            <ImageView
+                android:layout_width="60dp"
+                android:layout_height="53dp"
+                android:layout_gravity="center"
+                android:contentDescription="@null"
+                android:src="@drawable/settings_bg" />
 
-                <TextView
-                    android:id="@+id/card_text"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="Pick up your sword\nwhere you left off."
-                    android:textColor="@color/white"
-                    android:textSize="16sp" />
-            </LinearLayout>
         </LinearLayout>
 
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:layout_marginHorizontal="20dp"
             android:layout_marginTop="20dp"
             android:orientation="vertical">
 
@@ -92,78 +48,160 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginBottom="10dp"
-                android:text="Discover Inspiration"
+                android:text="@string/home_continue_section_title"
                 android:textColor="#FBF990"
                 android:textSize="20sp" />
 
             <LinearLayout
-                android:id="@+id/dailyTip"
+                android:id="@+id/continueLesson"
                 android:layout_width="match_parent"
                 android:layout_height="130dp"
                 android:background="@drawable/bg_linear"
+                android:clickable="true"
+                android:focusable="true"
+                android:foreground="?attr/selectableItemBackground"
                 android:gravity="center_vertical"
                 android:orientation="horizontal"
-                android:padding="15dp">
+                android:padding="20dp">
 
                 <ImageView
                     android:layout_width="120dp"
                     android:layout_height="120dp"
-                    android:padding="10dp"
-                    android:src="@drawable/tip_im" />
+                    android:contentDescription="@null"
+                    android:src="@drawable/books" />
 
                 <LinearLayout
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_gravity="center"
+                    android:layout_gravity="top"
                     android:layout_marginStart="20dp"
                     android:orientation="vertical">
 
                     <TextView
+                        android:id="@+id/textContinueLessonTitle"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_marginBottom="15dp"
-                        android:text="Daily Tip"
+                        android:text="@string/home_continue_card_title"
                         android:textColor="#FBF990"
-                        android:textSize="25sp" />
+                        android:textSize="18sp"
+                        android:textStyle="bold" />
 
-
+                    <TextView
+                        android:id="@+id/textContinueLessonMessage"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/home_continue_card_in_progress"
+                        android:textColor="@color/white"
+                        android:textSize="16sp" />
                 </LinearLayout>
             </LinearLayout>
 
             <LinearLayout
-                android:id="@+id/randomArticle"
                 android:layout_width="match_parent"
-                android:layout_height="130dp"
+                android:layout_height="wrap_content"
                 android:layout_marginTop="20dp"
-                android:background="@drawable/bg_linear"
-                android:gravity="center_vertical"
-                android:orientation="horizontal"
-                android:padding="15dp">
+                android:orientation="vertical">
 
-                <ImageView
-                    android:layout_width="120dp"
-                    android:layout_height="120dp"
-                    android:padding="10dp"
-                    android:src="@drawable/random_im" />
-
-                <LinearLayout
+                <TextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_gravity="center"
-                    android:layout_marginStart="20dp"
-                    android:orientation="vertical">
+                    android:layout_marginBottom="10dp"
+                    android:text="@string/home_inspiration_section_title"
+                    android:textColor="#FBF990"
+                    android:textSize="20sp" />
 
-                    <TextView
+                <LinearLayout
+                    android:id="@+id/dailyTip"
+                    android:layout_width="match_parent"
+                    android:layout_height="130dp"
+                    android:background="@drawable/bg_linear"
+                    android:clickable="true"
+                    android:focusable="true"
+                    android:foreground="?attr/selectableItemBackground"
+                    android:gravity="center_vertical"
+                    android:orientation="horizontal"
+                    android:padding="15dp">
+
+                    <ImageView
+                        android:layout_width="120dp"
+                        android:layout_height="120dp"
+                        android:contentDescription="@null"
+                        android:padding="10dp"
+                        android:src="@drawable/tip_im" />
+
+                    <LinearLayout
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:layout_marginBottom="15dp"
-                        android:text="Random Article"
-                        android:textColor="#FBF990"
-                        android:textSize="25sp" />
+                        android:layout_gravity="center"
+                        android:layout_marginStart="20dp"
+                        android:orientation="vertical">
 
+                        <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginBottom="8dp"
+                            android:text="@string/home_daily_tip_title"
+                            android:textColor="#FBF990"
+                            android:textSize="25sp"
+                            android:textStyle="bold" />
 
+                        <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="@string/home_daily_tip_subtitle"
+                            android:textColor="@color/white"
+                            android:textSize="16sp" />
+
+                    </LinearLayout>
+                </LinearLayout>
+
+                <LinearLayout
+                    android:id="@+id/randomArticle"
+                    android:layout_width="match_parent"
+                    android:layout_height="130dp"
+                    android:layout_marginTop="20dp"
+                    android:background="@drawable/bg_linear"
+                    android:clickable="true"
+                    android:focusable="true"
+                    android:foreground="?attr/selectableItemBackground"
+                    android:gravity="center_vertical"
+                    android:orientation="horizontal"
+                    android:padding="15dp">
+
+                    <ImageView
+                        android:layout_width="120dp"
+                        android:layout_height="120dp"
+                        android:contentDescription="@null"
+                        android:padding="10dp"
+                        android:src="@drawable/random_im" />
+
+                    <LinearLayout
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="center"
+                        android:layout_marginStart="20dp"
+                        android:orientation="vertical">
+
+                        <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginBottom="8dp"
+                            android:text="@string/home_random_article_title"
+                            android:textColor="#FBF990"
+                            android:textSize="25sp"
+                            android:textStyle="bold" />
+
+                        <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="@string/home_random_article_subtitle"
+                            android:textColor="@color/white"
+                            android:textSize="16sp" />
+
+                    </LinearLayout>
                 </LinearLayout>
             </LinearLayout>
         </LinearLayout>
     </LinearLayout>
-</LinearLayout>
+</ScrollView>

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -38,7 +38,17 @@
         android:id="@+id/nav_home"
         android:name="sr.otaryp.tesatyla.presentation.ui.main.HomeFragment"
         android:label="Home"
-        tools:layout="@layout/fragment_home" />
+        tools:layout="@layout/fragment_home">
+        <action
+            android:id="@+id/action_nav_home_to_nav_lessons"
+            app:destination="@id/nav_lessons" />
+        <action
+            android:id="@+id/action_nav_home_to_lessonDetailFragment"
+            app:destination="@id/lessonDetailFragment" />
+        <action
+            android:id="@+id/action_nav_home_to_articleDetailFragment"
+            app:destination="@id/articleDetailFragment" />
+    </fragment>
 
     <fragment
         android:id="@+id/nav_lessons"
@@ -63,5 +73,30 @@
         android:name="sr.otaryp.tesatyla.presentation.ui.focus.FocusFragment"
         android:label="Focus"
         tools:layout="@layout/fragment_focus" />
+
+    <fragment
+        android:id="@+id/lessonDetailFragment"
+        android:name="sr.otaryp.tesatyla.presentation.ui.lessons.LessonDetailFragment"
+        android:label="Lesson Detail"
+        tools:layout="@layout/fragment_lesson_detail" />
+
+    <fragment
+        android:id="@+id/lessonStepDetailFragment"
+        android:name="sr.otaryp.tesatyla.presentation.ui.lessons.LessonStepDetailFragment"
+        android:label="Lesson Step Detail"
+        tools:layout="@layout/fragment_lesson_step_detail" />
+
+    <fragment
+        android:id="@+id/articleDetailFragment"
+        android:name="sr.otaryp.tesatyla.presentation.ui.article.ArticleDetailFragment"
+        android:label="Article Detail"
+        tools:layout="@layout/fragment_article_detail">
+        <argument
+            android:name="articleTitle"
+            app:argType="string" />
+        <argument
+            android:name="articleContent"
+            app:argType="string" />
+    </fragment>
 
 </navigation>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -10,4 +10,23 @@
     <string name="onboarding_progress_description">Each completed lesson is a jewel in your crown. Watch your royal achievements grow brighter.</string>
     <string name="onboarding_enter_kingdom">Enter the Kingdom</string>
 
+    <string name="home_welcome_message">Rise, Young Knight!
+Your quests await.</string>
+    <string name="home_continue_section_title">Continue Lesson</string>
+    <string name="home_continue_card_title">Your quest continues</string>
+    <string name="home_continue_card_in_progress">Pick up your sword where you left it.</string>
+    <string name="home_continue_card_start">Start your first royal quest!</string>
+    <string name="home_inspiration_section_title">Discover Inspiration</string>
+    <string name="home_daily_tip_title">Daily Tip</string>
+    <string name="home_daily_tip_subtitle">A new royal whisper awaits each day.</string>
+    <string name="home_random_article_title">Random Article</string>
+    <string name="home_random_article_subtitle">Summon a scroll of fresh insight.</string>
+
+    <string name="dialog_tip_title">Royal Productivity Tip</string>
+    <string name="dialog_tip_next">Next Tip</string>
+    <string name="dialog_tip_close">Got it</string>
+    <string name="dialog_tip_position">Tip %1$d of %2$d</string>
+    <string name="dialog_tip_swipe_hint">Swipe left or right to explore more wisdom.</string>
+
+    <string name="article_back">Back</string>
 </resources>


### PR DESCRIPTION
## Summary
- add an inspiration repository for articles and royal tips plus lesson progress preferences
- redesign the home fragment UI copy and wire up navigation for lessons, daily tips, and random articles
- implement the daily tip scroll dialog with swipe support and update article detail rendering for safe-args driven content

## Testing
- ./gradlew assembleDebug *(fails: Android SDK not available in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dda7041fe4832ab5d8125614e8bbc3