### PR TITLE
Implement lesson list fragment with royal quest adapter

### DIFF
--- a/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/lessons/LessonAdapter.kt
+++ b/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/lessons/LessonAdapter.kt
@@ -1,0 +1,65 @@
+package sr.otaryp.tesatyla.presentation.ui.lessons
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import sr.otaryp.tesatyla.R
+import sr.otaryp.tesatyla.databinding.ItemLessonBinding
+
+class LessonAdapter(
+    private val onLessonSelected: (LessonListItem) -> Unit
+) : ListAdapter<LessonListItem, LessonAdapter.LessonViewHolder>(DiffCallback) {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): LessonViewHolder {
+        val binding = ItemLessonBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        return LessonViewHolder(binding)
+    }
+
+    override fun onBindViewHolder(holder: LessonViewHolder, position: Int) {
+        holder.bind(getItem(position), onLessonSelected)
+    }
+
+    class LessonViewHolder(
+        private val binding: ItemLessonBinding
+    ) : RecyclerView.ViewHolder(binding.root) {
+
+        fun bind(item: LessonListItem, onLessonSelected: (LessonListItem) -> Unit) {
+            binding.titleTv.text = item.title
+            binding.textDescription.text = item.description
+
+            val iconRes = if (item.isCompleted) {
+                R.drawable.shield_bg
+            } else {
+                R.drawable.shield_gray
+            }
+            binding.levelIm.setImageResource(iconRes)
+
+            val buttonTextRes = if (item.isCompleted) {
+                R.string.lesson_action_review
+            } else {
+                R.string.lesson_action_continue
+            }
+            binding.btnContinue.setText(buttonTextRes)
+
+            binding.btnContinue.setOnClickListener { onLessonSelected(item) }
+        }
+    }
+
+    private object DiffCallback : DiffUtil.ItemCallback<LessonListItem>() {
+        override fun areItemsTheSame(oldItem: LessonListItem, newItem: LessonListItem): Boolean =
+            oldItem.id == newItem.id
+
+        override fun areContentsTheSame(oldItem: LessonListItem, newItem: LessonListItem): Boolean =
+            oldItem == newItem
+    }
+}
+
+
+data class LessonListItem(
+    val id: Int,
+    val title: String,
+    val description: String,
+    val isCompleted: Boolean
+)

--- a/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/lessons/LessonListFragment.kt
+++ b/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/lessons/LessonListFragment.kt
@@ -1,60 +1,133 @@
 package sr.otaryp.tesatyla.presentation.ui.lessons
 
 import android.os.Bundle
-import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import androidx.navigation.fragment.findNavController
+import androidx.recyclerview.widget.LinearLayoutManager
 import sr.otaryp.tesatyla.R
+import sr.otaryp.tesatyla.data.preferences.LessonProgressPreferences
+import sr.otaryp.tesatyla.databinding.FragmentLessonListBinding
+import kotlin.LazyThreadSafetyMode
 
-// TODO: Rename parameter arguments, choose names that match
-// the fragment initialization parameters, e.g. ARG_ITEM_NUMBER
-private const val ARG_PARAM1 = "param1"
-private const val ARG_PARAM2 = "param2"
-
-/**
- * A simple [Fragment] subclass.
- * Use the [LessonListFragment.newInstance] factory method to
- * create an instance of this fragment.
- */
 class LessonListFragment : Fragment() {
-    // TODO: Rename and change types of parameters
-    private var param1: String? = null
-    private var param2: String? = null
 
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        arguments?.let {
-            param1 = it.getString(ARG_PARAM1)
-            param2 = it.getString(ARG_PARAM2)
-        }
+    private var _binding: FragmentLessonListBinding? = null
+    private val binding get() = _binding!!
+
+    private val lessonAdapter by lazy(LazyThreadSafetyMode.NONE) {
+        LessonAdapter(::onLessonSelected)
     }
 
     override fun onCreateView(
-        inflater: LayoutInflater, container: ViewGroup?,
+        inflater: LayoutInflater,
+        container: ViewGroup?,
         savedInstanceState: Bundle?
-    ): View? {
-        // Inflate the layout for this fragment
-        return inflater.inflate(R.layout.fragment_lesson_list, container, false)
+    ): View {
+        _binding = FragmentLessonListBinding.inflate(inflater, container, false)
+        return binding.root
     }
 
-    companion object {
-        /**
-         * Use this factory method to create a new instance of
-         * this fragment using the provided parameters.
-         *
-         * @param param1 Parameter 1.
-         * @param param2 Parameter 2.
-         * @return A new instance of fragment LessonListFragment.
-         */
-        // TODO: Rename and change types and number of parameters
-        @JvmStatic
-        fun newInstance(param1: String, param2: String) =
-            LessonListFragment().apply {
-                arguments = Bundle().apply {
-                    putString(ARG_PARAM1, param1)
-                    putString(ARG_PARAM2, param2)
-                }
-            }
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        setupToolbar()
+        setupRecyclerView()
+        lessonAdapter.submitList(lessonExamples)
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+
+    private fun setupToolbar() {
+        binding.btnBack.setOnClickListener {
+            findNavController().navigateUp()
+        }
+    }
+
+    private fun setupRecyclerView() {
+        binding.rvListLessons.apply {
+            layoutManager = LinearLayoutManager(requireContext())
+            adapter = lessonAdapter
+            setHasFixedSize(true)
+        }
+    }
+
+    private fun onLessonSelected(lesson: LessonListItem) {
+        LessonProgressPreferences.setCurrentLesson(
+            requireContext(),
+            lesson.id,
+            lesson.title
+        )
+        findNavController().navigate(R.id.lessonDetailFragment)
+    }
+
+    private val lessonExamples by lazy(LazyThreadSafetyMode.NONE) {
+        listOf(
+            LessonListItem(
+                id = 1,
+                title = getString(R.string.lesson_title_pomodoro_trials),
+                description = getString(R.string.lesson_description_pomodoro_trials),
+                isCompleted = true
+            ),
+            LessonListItem(
+                id = 2,
+                title = getString(R.string.lesson_title_scrolls_of_order),
+                description = getString(R.string.lesson_description_scrolls_of_order),
+                isCompleted = true
+            ),
+            LessonListItem(
+                id = 3,
+                title = getString(R.string.lesson_title_defend_against_distractions),
+                description = getString(R.string.lesson_description_defend_against_distractions),
+                isCompleted = false
+            ),
+            LessonListItem(
+                id = 4,
+                title = getString(R.string.lesson_title_timekeepers_path),
+                description = getString(R.string.lesson_description_timekeepers_path),
+                isCompleted = false
+            ),
+            LessonListItem(
+                id = 5,
+                title = getString(R.string.lesson_title_procrastination_dragon),
+                description = getString(R.string.lesson_description_procrastination_dragon),
+                isCompleted = false
+            ),
+            LessonListItem(
+                id = 6,
+                title = getString(R.string.lesson_title_focus_forge),
+                description = getString(R.string.lesson_description_focus_forge),
+                isCompleted = false
+            ),
+            LessonListItem(
+                id = 7,
+                title = getString(R.string.lesson_title_energy_management),
+                description = getString(R.string.lesson_description_energy_management),
+                isCompleted = false
+            ),
+            LessonListItem(
+                id = 8,
+                title = getString(R.string.lesson_title_task_alchemy),
+                description = getString(R.string.lesson_description_task_alchemy),
+                isCompleted = false
+            ),
+            LessonListItem(
+                id = 9,
+                title = getString(R.string.lesson_title_habit_loop),
+                description = getString(R.string.lesson_description_habit_loop),
+                isCompleted = false
+            ),
+            LessonListItem(
+                id = 10,
+                title = getString(R.string.lesson_title_reflection_chamber),
+                description = getString(R.string.lesson_description_reflection_chamber),
+                isCompleted = false
+            )
+        )
     }
 }
+

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -29,4 +29,27 @@ Your quests await.</string>
 
 
     <string name="article_back">Back</string>
+
+    <string name="lesson_action_continue">Continue Quest</string>
+    <string name="lesson_action_review">Review Quest</string>
+    <string name="lesson_title_pomodoro_trials">Pomodoro Trials</string>
+    <string name="lesson_description_pomodoro_trials">Train in timed battles: 25 minutes of focus, 5 minutes of rest.</string>
+    <string name="lesson_title_scrolls_of_order">Scrolls of Order</string>
+    <string name="lesson_description_scrolls_of_order">Master the art of daily to-do lists to command your kingdom wisely.</string>
+    <string name="lesson_title_defend_against_distractions">Defend Against Distractions</string>
+    <string name="lesson_description_defend_against_distractions">Learn strategies to guard your focus from invading chaos.</string>
+    <string name="lesson_title_timekeepers_path">The Timekeeper’s Path</string>
+    <string name="lesson_description_timekeepers_path">Harness time blocks to rule your day with clarity and strength.</string>
+    <string name="lesson_title_procrastination_dragon">The Procrastination Dragon</string>
+    <string name="lesson_description_procrastination_dragon">Face the beast of delay and strike with proven action techniques.</string>
+    <string name="lesson_title_focus_forge">The Focus Forge</string>
+    <string name="lesson_description_focus_forge">Sharpen your concentration with practical drills and single-tasking mastery.</string>
+    <string name="lesson_title_energy_management">Energy Management</string>
+    <string name="lesson_description_energy_management">Align royal duties with your natural energy cycles and let rest refuel you.</string>
+    <string name="lesson_title_task_alchemy">Task Alchemy</string>
+    <string name="lesson_description_task_alchemy">Transform overwhelming quests into clear, actionable steps fit for victory.</string>
+    <string name="lesson_title_habit_loop">The Habit Loop</string>
+    <string name="lesson_description_habit_loop">Understand how habits are forged and craft routines that lead to success.</string>
+    <string name="lesson_title_reflection_chamber">The Reflection Chamber</string>
+    <string name="lesson_description_reflection_chamber">Review the day’s wins, lessons, and areas to improve for steady progress.</string>
 </resources>


### PR DESCRIPTION
## Summary
- create a recycler view adapter to render royal quest themed lessons
- implement LessonListFragment to populate the lesson list and handle navigation
- add string resources for lesson titles, descriptions, and call-to-action text

## Testing
- ❌ `./gradlew :app:compileDebugKotlin` *(requires local Android SDK)*

------
https://chatgpt.com/codex/tasks/task_e_68de569f1e30832aa1563a97f512aa03