### PR TITLE
Implement Room-backed lesson progress tracking

### DIFF
--- a/app/src/main/java/sr/otaryp/tesatyla/data/lessons/LessonDao.kt
+++ b/app/src/main/java/sr/otaryp/tesatyla/data/lessons/LessonDao.kt
@@ -1,0 +1,59 @@
+package sr.otaryp.tesatyla.data.lessons
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import androidx.room.Transaction
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface LessonDao {
+
+    @Transaction
+    @Query("SELECT * FROM lessons ORDER BY id")
+    fun getLessonsWithSteps(): Flow<List<LessonWithSteps>>
+
+    @Transaction
+    @Query("SELECT * FROM lessons WHERE id = :lessonId")
+    fun getLessonWithSteps(lessonId: Int): Flow<LessonWithSteps>
+
+    @Query("SELECT * FROM lesson_steps WHERE lessonId = :lessonId ORDER BY number")
+    fun getStepsForLesson(lessonId: Int): Flow<List<LessonStepEntity>>
+
+    @Query("SELECT * FROM lesson_steps WHERE id = :stepId")
+    fun getStep(stepId: Int): Flow<LessonStepEntity>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertLessons(lessons: List<LessonEntity>)
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertSteps(steps: List<LessonStepEntity>)
+
+    @Query("UPDATE lesson_steps SET isCompleted = :isCompleted WHERE id = :stepId")
+    suspend fun updateStepCompletion(stepId: Int, isCompleted: Boolean)
+
+    @Query("UPDATE lessons SET isCompleted = :isCompleted WHERE id = :lessonId")
+    suspend fun updateLessonCompletion(lessonId: Int, isCompleted: Boolean)
+
+    @Query("SELECT COUNT(*) FROM lessons")
+    suspend fun countLessons(): Int
+
+    @Query("SELECT COUNT(*) FROM lesson_steps WHERE lessonId = :lessonId")
+    suspend fun countStepsForLesson(lessonId: Int): Int
+
+    @Query("SELECT COUNT(*) FROM lesson_steps WHERE lessonId = :lessonId AND isCompleted = 1")
+    suspend fun countCompletedStepsForLesson(lessonId: Int): Int
+
+    @Query("SELECT id FROM lessons WHERE id > :lessonId ORDER BY id LIMIT 1")
+    suspend fun findNextLessonId(lessonId: Int): Int?
+
+    @Query("SELECT * FROM lessons WHERE id = :lessonId")
+    suspend fun getLessonById(lessonId: Int): LessonEntity?
+
+    @Query("UPDATE lesson_steps SET isCompleted = 0 WHERE lessonId = :lessonId")
+    suspend fun resetStepsForLesson(lessonId: Int)
+
+    @Query("SELECT * FROM lesson_steps WHERE lessonId = :lessonId AND isCompleted = 0 ORDER BY number LIMIT 1")
+    suspend fun getNextIncompleteStep(lessonId: Int): LessonStepEntity?
+}

--- a/app/src/main/java/sr/otaryp/tesatyla/data/lessons/LessonDatabase.kt
+++ b/app/src/main/java/sr/otaryp/tesatyla/data/lessons/LessonDatabase.kt
@@ -1,0 +1,34 @@
+package sr.otaryp.tesatyla.data.lessons
+
+import android.content.Context
+import androidx.room.Database
+import androidx.room.Room
+import androidx.room.RoomDatabase
+
+@Database(
+    entities = [LessonEntity::class, LessonStepEntity::class],
+    version = 1,
+    exportSchema = false
+)
+abstract class LessonDatabase : RoomDatabase() {
+
+    abstract fun lessonDao(): LessonDao
+
+    companion object {
+        @Volatile
+        private var INSTANCE: LessonDatabase? = null
+
+        fun getInstance(context: Context): LessonDatabase {
+            return INSTANCE ?: synchronized(this) {
+                val instance = Room.databaseBuilder(
+                    context.applicationContext,
+                    LessonDatabase::class.java,
+                    "lesson_database"
+                ).fallbackToDestructiveMigration()
+                    .build()
+                INSTANCE = instance
+                instance
+            }
+        }
+    }
+}

--- a/app/src/main/java/sr/otaryp/tesatyla/data/lessons/LessonEntity.kt
+++ b/app/src/main/java/sr/otaryp/tesatyla/data/lessons/LessonEntity.kt
@@ -1,0 +1,13 @@
+package sr.otaryp.tesatyla.data.lessons
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "lessons")
+data class LessonEntity(
+    @PrimaryKey val id: Int,
+    val title: String,
+    val description: String,
+    val teaching: String,
+    val isCompleted: Boolean = false
+)

--- a/app/src/main/java/sr/otaryp/tesatyla/data/lessons/LessonRepository.kt
+++ b/app/src/main/java/sr/otaryp/tesatyla/data/lessons/LessonRepository.kt
@@ -1,0 +1,98 @@
+package sr.otaryp.tesatyla.data.lessons
+
+import android.content.Context
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.launch
+
+class LessonRepository private constructor(
+    private val lessonDao: LessonDao
+) {
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    init {
+        scope.launch { prepopulateIfNeeded() }
+    }
+
+    fun observeLessons(): Flow<List<LessonWithSteps>> = lessonDao.getLessonsWithSteps()
+
+    fun observeLesson(lessonId: Int): Flow<LessonWithSteps> = lessonDao.getLessonWithSteps(lessonId)
+
+    fun observeLessonSteps(lessonId: Int): Flow<List<LessonStepEntity>> =
+        lessonDao.getStepsForLesson(lessonId)
+
+    fun observeStep(stepId: Int): Flow<LessonStepEntity> = lessonDao.getStep(stepId)
+
+    suspend fun completeStep(lessonId: Int, stepId: Int): StepCompletionResult {
+        lessonDao.updateStepCompletion(stepId, true)
+        val totalSteps = lessonDao.countStepsForLesson(lessonId)
+        val completedSteps = lessonDao.countCompletedStepsForLesson(lessonId)
+        val isLessonCompleted = completedSteps == totalSteps && totalSteps > 0
+        lessonDao.updateLessonCompletion(lessonId, isLessonCompleted)
+        return if (isLessonCompleted) {
+            StepCompletionResult.LessonCompleted
+        } else {
+            StepCompletionResult.StepCompleted
+        }
+    }
+
+    suspend fun resetLesson(lessonId: Int) {
+        lessonDao.resetStepsForLesson(lessonId)
+        lessonDao.updateLessonCompletion(lessonId, false)
+    }
+
+    suspend fun getNextIncompleteStep(lessonId: Int): LessonStepEntity? =
+        lessonDao.getNextIncompleteStep(lessonId)
+
+    suspend fun getNextLessonId(currentLessonId: Int): Int? =
+        lessonDao.findNextLessonId(currentLessonId)
+
+    suspend fun getLessonById(lessonId: Int): LessonEntity? = lessonDao.getLessonById(lessonId)
+
+    private suspend fun prepopulateIfNeeded() {
+        if (lessonDao.countLessons() > 0) return
+
+        val lessons = LessonSeedData.lessons.map { seed ->
+            LessonEntity(
+                id = seed.id,
+                title = seed.title,
+                description = seed.description,
+                teaching = seed.teaching
+            )
+        }
+        val steps = LessonSeedData.lessons.flatMap { lesson ->
+            lesson.steps.map { step ->
+                LessonStepEntity(
+                    id = lesson.id * 10 + step.number,
+                    lessonId = lesson.id,
+                    number = step.number,
+                    title = step.title,
+                    theory = step.theory,
+                    practice = step.practice
+                )
+            }
+        }
+        lessonDao.insertLessons(lessons)
+        lessonDao.insertSteps(steps)
+    }
+
+    companion object {
+        @Volatile
+        private var INSTANCE: LessonRepository? = null
+
+        fun getInstance(context: Context): LessonRepository {
+            return INSTANCE ?: synchronized(this) {
+                val database = LessonDatabase.getInstance(context)
+                LessonRepository(database.lessonDao()).also { INSTANCE = it }
+            }
+        }
+    }
+}
+
+sealed interface StepCompletionResult {
+    object StepCompleted : StepCompletionResult
+    object LessonCompleted : StepCompletionResult
+}

--- a/app/src/main/java/sr/otaryp/tesatyla/data/lessons/LessonSeedData.kt
+++ b/app/src/main/java/sr/otaryp/tesatyla/data/lessons/LessonSeedData.kt
@@ -1,0 +1,401 @@
+package sr.otaryp.tesatyla.data.lessons
+
+private data class LessonSeed(
+    val id: Int,
+    val title: String,
+    val description: String,
+    val teaching: String,
+    val steps: List<LessonStepSeed>
+)
+
+private data class LessonStepSeed(
+    val number: Int,
+    val title: String,
+    val theory: String,
+    val practice: String
+)
+
+internal object LessonSeedData {
+    val lessons: List<LessonSeed> = listOf(
+        LessonSeed(
+            id = 1,
+            title = "Lesson 1: Pomodoro Trials",
+            description = "Train in timed battles: 25 minutes of focus, 5 minutes of rest.",
+            teaching = "This lesson introduces you to the Pomodoro Technique — a method to increase focus and avoid burnout. By working in short, structured sprints, you’ll learn to manage your energy, stay consistent, and reduce mental fatigue.",
+            steps = listOf(
+                LessonStepSeed(
+                    number = 1,
+                    title = "Step 1: Learn the 25–5 Pomodoro structure",
+                    theory = "The Pomodoro method divides work into cycles of 25 minutes of focused work followed by 5 minutes of rest. These short sprints allow the brain to recharge regularly, preventing fatigue and increasing concentration. Long, uninterrupted work sessions often reduce effectiveness over time.",
+                    practice = "Read about the Pomodoro cycle. Write down the structure somewhere visible: 25 minutes work → 5 minutes rest → repeat 4 times → then a longer break of 15–30 minutes."
+                ),
+                LessonStepSeed(
+                    number = 2,
+                    title = "Step 2: Set a 25-minute timer and focus on one task",
+                    theory = "Focusing on a single task at a time improves productivity and flow. Multitasking drains attention and slows progress. Commit fully to one task during Pomodoro.",
+                    practice = "Pick one task from your to-do list. Close all other tabs, silence notifications, and start a 25-minute timer. Focus solely on this task until the timer ends."
+                ),
+                LessonStepSeed(
+                    number = 3,
+                    title = "Step 3: Take a 5-minute break",
+                    theory = "Breaks restore attention, improve memory, and allow the brain to process information. Without them, productivity and quality drop.",
+                    practice = "Stand up, stretch, or walk during your 5-minute break. Avoid distractions like social media to maintain focus for the next Pomodoro."
+                ),
+                LessonStepSeed(
+                    number = 4,
+                    title = "Step 4: Repeat at least 4 times today",
+                    theory = "Consistency reinforces the habit and trains your brain to focus in cycles. Repetition builds rhythm and discipline.",
+                    practice = "Complete four full Pomodoro cycles today, following the structure you learned."
+                ),
+                LessonStepSeed(
+                    number = 5,
+                    title = "Step 5: Write down how your focus changed",
+                    theory = "Reflection helps you see progress, identify obstacles, and adjust strategies for improvement.",
+                    practice = "At the end of the day, write a short note: How did your focus change? Did tasks feel easier or more manageable?"
+                )
+            )
+        ),
+        LessonSeed(
+            id = 2,
+            title = "Lesson 2: Scrolls of Order",
+            description = "Master the art of daily to-do lists to command your kingdom wisely.",
+            teaching = "This lesson teaches how to prioritize tasks effectively. By focusing on the most important things first, you’ll reduce overwhelm, increase clarity, and finish meaningful work without feeling scattered.",
+            steps = listOf(
+                LessonStepSeed(
+                    number = 1,
+                    title = "Step 1: Learn the “3 priorities” method",
+                    theory = "Limiting yourself to 3 priorities prevents decision fatigue and ensures focus on what really matters. Trying to do too many things at once leads to stress and lower productivity.",
+                    practice = "Read about the 3-priority approach and note why limiting tasks works."
+                ),
+                LessonStepSeed(
+                    number = 2,
+                    title = "Step 2: Write down 3 tasks: Must Do, Should Do, Nice to Do",
+                    theory = "Categorizing tasks by importance helps you clearly see where to start. “Must Do” tasks are critical; “Should Do” tasks are important but less urgent; “Nice to Do” are optional.",
+                    practice = "Write today’s tasks in these categories."
+                ),
+                LessonStepSeed(
+                    number = 3,
+                    title = "Step 3: Do the “Must Do” task first",
+                    theory = "Tackling the most important task first ensures progress on what really matters, even if distractions or fatigue arise later.",
+                    practice = "Start with your top “Must Do” task and commit to completing it before anything else."
+                ),
+                LessonStepSeed(
+                    number = 4,
+                    title = "Step 4: Review your list at the end of the day",
+                    theory = "Reflection helps you understand how realistic your priorities were and adjust planning for tomorrow.",
+                    practice = "Check off completed tasks and note unfinished ones for rescheduling."
+                ),
+                LessonStepSeed(
+                    number = 5,
+                    title = "Step 5: Reflect on how focusing on fewer tasks felt",
+                    theory = "Awareness of your productivity habits improves planning and focus over time.",
+                    practice = "Write a short note: Did concentrating on fewer tasks reduce stress? Did it help you finish more important work?"
+                )
+            )
+        ),
+        LessonSeed(
+            id = 3,
+            title = "Lesson 3: Defend Against Distractions",
+            description = "Learn strategies to guard your focus from invading chaos.",
+            teaching = "This lesson helps you identify and control distractions, improving focus and maintaining deep work sessions.",
+            steps = listOf(
+                LessonStepSeed(
+                    number = 1,
+                    title = "Step 1: Learn how distractions reset focus",
+                    theory = "Each interruption requires the brain to refocus, which takes time and energy. Even small distractions reduce efficiency.",
+                    practice = "Read about the cognitive cost of interruptions."
+                ),
+                LessonStepSeed(
+                    number = 2,
+                    title = "Step 2: Identify your 3 biggest distractions",
+                    theory = "Knowing your main distractions allows targeted strategies to minimize them.",
+                    practice = "List the top three distractions you face while working (e.g., phone notifications, chat apps, social media)."
+                ),
+                LessonStepSeed(
+                    number = 3,
+                    title = "Step 3: Block at least one",
+                    theory = "Removing at least one major distraction will make it easier to enter deep focus.",
+                    practice = "Turn off notifications, enable “Do Not Disturb,” or close unnecessary apps."
+                ),
+                LessonStepSeed(
+                    number = 4,
+                    title = "Step 4: Do a 1-hour deep work session",
+                    theory = "Practicing sustained focus strengthens attention muscles and trains resistance to distractions.",
+                    practice = "Choose one task and work uninterrupted for 1 hour."
+                ),
+                LessonStepSeed(
+                    number = 5,
+                    title = "Step 5: Reflect: what was harder — starting or staying focused?",
+                    theory = "Understanding where focus breaks down helps you develop stronger habits.",
+                    practice = "Write a note on which part felt more challenging and why."
+                )
+            )
+        ),
+        LessonSeed(
+            id = 4,
+            title = "Lesson 4: The Timekeeper’s Path",
+            description = "Harness time blocks to rule your day with clarity and strength.",
+            teaching = "Learn to use time blocking to maximize energy and productivity by aligning tasks with your natural rhythms.",
+            steps = listOf(
+                LessonStepSeed(
+                    number = 1,
+                    title = "Step 1: Learn time blocking basics",
+                    theory = "Time blocking schedules specific tasks during defined periods, reducing decision fatigue and overcommitment.",
+                    practice = "Read about time-blocking methods and benefits."
+                ),
+                LessonStepSeed(
+                    number = 2,
+                    title = "Step 2: Look at your energy peaks (morning/afternoon/evening)",
+                    theory = "Everyone has periods of high and low energy. Aligning tasks with energy peaks improves output.",
+                    practice = "Note when you feel most alert during the day."
+                ),
+                LessonStepSeed(
+                    number = 3,
+                    title = "Step 3: Plan tomorrow into blocks (focus, rest, leisure)",
+                    theory = "Structuring the day ensures balance between work and recovery, increasing consistency and focus.",
+                    practice = "Schedule your tasks into 30–60 minute blocks for tomorrow, including breaks."
+                ),
+                LessonStepSeed(
+                    number = 4,
+                    title = "Step 4: Do your hardest task during peak energy",
+                    theory = "High-energy periods are ideal for challenging tasks requiring concentration and creativity.",
+                    practice = "Complete your most demanding task during your identified energy peak."
+                ),
+                LessonStepSeed(
+                    number = 5,
+                    title = "Step 5: Review what worked and adjust for next day",
+                    theory = "Reflection allows continuous improvement in planning and productivity.",
+                    practice = "Write what worked, what didn’t, and how to adjust tomorrow."
+                )
+            )
+        ),
+        LessonSeed(
+            id = 5,
+            title = "Lesson 5: The Procrastination Dragon",
+            description = "Face the beast of delay and strike with proven action techniques.",
+            teaching = "This lesson helps you overcome procrastination by breaking down tasks into actionable steps and building momentum.",
+            steps = listOf(
+                LessonStepSeed(
+                    number = 1,
+                    title = "Step 1: Learn why procrastination thrives on vague goals",
+                    theory = "Ambiguous or large tasks feel overwhelming, causing avoidance. Clear, concrete actions reduce resistance.",
+                    practice = "Read about why specificity combats procrastination."
+                ),
+                LessonStepSeed(
+                    number = 2,
+                    title = "Step 2: Pick one task you’ve been avoiding",
+                    theory = "Tackling even a small neglected task reduces mental load and builds confidence.",
+                    practice = "Select one task you’ve been putting off."
+                ),
+                LessonStepSeed(
+                    number = 3,
+                    title = "Step 3: Break it into the smallest possible step",
+                    theory = "Micro-steps make starting easy and reduce fear or inertia.",
+                    practice = "Write down the first tiny action you can take today."
+                ),
+                LessonStepSeed(
+                    number = 4,
+                    title = "Step 4: Do that first step immediately",
+                    theory = "Action creates momentum; progress, even small, motivates further action.",
+                    practice = "Complete the first micro-step now, without delay."
+                ),
+                LessonStepSeed(
+                    number = 5,
+                    title = "Step 5: Note how momentum carried you further",
+                    theory = "Reflection reinforces the habit of starting small to defeat procrastination.",
+                    practice = "Write how completing the first step affected your motivation to continue."
+                )
+            )
+        ),
+        LessonSeed(
+            id = 6,
+            title = "Lesson 6: The Focus Forge",
+            description = "Sharpen your concentration with practical drills and single-tasking mastery.",
+            teaching = "This lesson strengthens the ability to maintain focus and resist multitasking.",
+            steps = listOf(
+                LessonStepSeed(
+                    number = 1,
+                    title = "Step 1: Learn why multitasking weakens focus",
+                    theory = "Switching tasks divides attention and reduces efficiency. Single-tasking maximizes cognitive resources.",
+                    practice = "Read about the science of multitasking and focus."
+                ),
+                LessonStepSeed(
+                    number = 2,
+                    title = "Step 2: Pick one task and commit to finish it",
+                    theory = "Commitment enhances focus and ensures completion before moving on.",
+                    practice = "Choose one task and block off time to finish it fully."
+                ),
+                LessonStepSeed(
+                    number = 3,
+                    title = "Step 3: Write down any distractions instead of acting on them",
+                    theory = "Noting distractions prevents derailment while acknowledging them.",
+                    practice = "Keep a distraction list nearby. When something pops up, jot it down instead of switching tasks."
+                ),
+                LessonStepSeed(
+                    number = 4,
+                    title = "Step 4: Complete the task fully before switching",
+                    theory = "Full completion reinforces discipline and avoids unfinished work clutter.",
+                    practice = "Finish your chosen task without interruption."
+                ),
+                LessonStepSeed(
+                    number = 5,
+                    title = "Step 5: Reflect: how did it feel compared to multitasking?",
+                    theory = "Awareness of your workflow improves habits and focus strategy.",
+                    practice = "Note differences in energy, speed, and satisfaction."
+                )
+            )
+        ),
+        LessonSeed(
+            id = 7,
+            title = "Lesson 7: Energy Management",
+            description = "Align royal duties with your natural energy cycles and let rest refuel you.",
+            teaching = "Learn to align tasks with natural energy cycles to optimize productivity and avoid burnout.",
+            steps = listOf(
+                LessonStepSeed(
+                    number = 1,
+                    title = "Step 1: Learn how productivity depends on energy cycles",
+                    theory = "Mental performance fluctuates during the day. Working against energy peaks reduces efficiency.",
+                    practice = "Read about circadian rhythms and productivity patterns."
+                ),
+                LessonStepSeed(
+                    number = 2,
+                    title = "Step 2: Track your energy levels (morning, afternoon, evening)",
+                    theory = "Observing your own energy helps identify optimal work periods.",
+                    practice = "Rate energy levels for different times of day for 1–2 days."
+                ),
+                LessonStepSeed(
+                    number = 3,
+                    title = "Step 3: Identify your peak focus period",
+                    theory = "Knowing your highest energy window allows strategic scheduling of hard tasks.",
+                    practice = "Mark the time of day when concentration is strongest."
+                ),
+                LessonStepSeed(
+                    number = 4,
+                    title = "Step 4: Schedule hardest work at that time tomorrow",
+                    theory = "Aligning high-effort work with peak energy ensures better output and reduces stress.",
+                    practice = "Plan your next day accordingly."
+                ),
+                LessonStepSeed(
+                    number = 5,
+                    title = "Step 5: Compare results with today’s performance",
+                    theory = "Reflection validates the effectiveness of energy-aligned scheduling.",
+                    practice = "Note if productivity improved compared to working at low-energy times."
+                )
+            )
+        ),
+        LessonSeed(
+            id = 8,
+            title = "Lesson 8: Task Alchemy",
+            description = "Transform overwhelming quests into clear, actionable steps fit for victory.",
+            teaching = "Learn to break large projects into smaller, manageable tasks, reducing overwhelm and increasing progress visibility.",
+            steps = listOf(
+                LessonStepSeed(
+                    number = 1,
+                    title = "Step 1: Learn why projects overwhelm without breakdown",
+                    theory = "Large tasks seem impossible, triggering procrastination. Breaking them into milestones reduces anxiety.",
+                    practice = "Read about project decomposition strategies."
+                ),
+                LessonStepSeed(
+                    number = 2,
+                    title = "Step 2: Take one big project and split into milestones",
+                    theory = "Milestones create mini-goals, making progress tangible.",
+                    practice = "Identify 2–3 key milestones for one project."
+                ),
+                LessonStepSeed(
+                    number = 3,
+                    title = "Step 3: Break a milestone into tasks",
+                    theory = "Concrete tasks transform milestones into actionable steps.",
+                    practice = "List specific tasks needed to complete one milestone."
+                ),
+                LessonStepSeed(
+                    number = 4,
+                    title = "Step 4: Break one task into sub-tasks",
+                    theory = "Micro-actions make starting effortless and maintain momentum.",
+                    practice = "Write 2–3 small sub-tasks for one task."
+                ),
+                LessonStepSeed(
+                    number = 5,
+                    title = "Step 5: Complete one sub-task today and mark progress",
+                    theory = "Visible progress motivates further action and reduces overwhelm.",
+                    practice = "Complete a sub-task and note it in your progress tracker."
+                )
+            )
+        ),
+        LessonSeed(
+            id = 9,
+            title = "Lesson 9: The Habit Loop",
+            description = "Understand how habits are forged and craft routines that lead to success.",
+            teaching = "Learn to change or build habits using the cue → routine → reward model.",
+            steps = listOf(
+                LessonStepSeed(
+                    number = 1,
+                    title = "Step 1: Learn cue → routine → reward model",
+                    theory = "Habits are formed when a cue triggers a routine that provides a reward. Understanding this loop allows behavior modification.",
+                    practice = "Read about habit loops and examples."
+                ),
+                LessonStepSeed(
+                    number = 2,
+                    title = "Step 2: Identify one unhelpful habit",
+                    theory = "Self-awareness is the first step toward change.",
+                    practice = "Choose one habit that reduces productivity or focus."
+                ),
+                LessonStepSeed(
+                    number = 3,
+                    title = "Step 3: Define a new routine to replace it",
+                    theory = "Replacing routines, not eliminating cues, makes habit change sustainable.",
+                    practice = "Plan a positive routine that serves the same cue."
+                ),
+                LessonStepSeed(
+                    number = 4,
+                    title = "Step 4: Attach the new routine to the same cue",
+                    theory = "Consistency strengthens the new habit loop.",
+                    practice = "Link your new routine to the old cue."
+                ),
+                LessonStepSeed(
+                    number = 5,
+                    title = "Step 5: Test it for 7 days and track with checkmarks",
+                    theory = "Repetition solidifies new habits into automatic behavior.",
+                    practice = "Follow the new routine daily and mark progress."
+                )
+            )
+        ),
+        LessonSeed(
+            id = 10,
+            title = "Lesson 10: The Reflection Chamber",
+            description = "Review the day’s wins, lessons, and areas to improve for steady progress.",
+            teaching = "Reflection builds self-awareness, helps identify patterns, and improves decision-making and productivity.",
+            steps = listOf(
+                LessonStepSeed(
+                    number = 1,
+                    title = "Step 1: Learn why reflection matters for progress",
+                    theory = "Regular reflection provides insight into what works, what hinders, and how to plan better.",
+                    practice = "Read about the benefits of journaling and reflection."
+                ),
+                LessonStepSeed(
+                    number = 2,
+                    title = "Step 2: Each evening, write 3 questions: What did I do? What blocked me? What’s next?",
+                    theory = "Structured questions guide productive reflection and learning.",
+                    practice = "Prepare a daily reflection sheet with these questions."
+                ),
+                LessonStepSeed(
+                    number = 3,
+                    title = "Step 3: Answer them for today",
+                    theory = "Documenting actions and obstacles increases accountability and clarity.",
+                    practice = "Write your answers honestly each evening."
+                ),
+                LessonStepSeed(
+                    number = 4,
+                    title = "Step 4: Repeat for 3 days in a row",
+                    theory = "Habitual reflection strengthens learning and self-awareness.",
+                    practice = "Continue journaling for 3 consecutive days."
+                ),
+                LessonStepSeed(
+                    number = 5,
+                    title = "Step 5: Review your notes and see patterns",
+                    theory = "Recognizing trends allows adjustment of strategies for greater efficiency.",
+                    practice = "Analyze your notes to find recurring challenges or successes."
+                )
+            )
+        )
+    )
+}

--- a/app/src/main/java/sr/otaryp/tesatyla/data/lessons/LessonStepEntity.kt
+++ b/app/src/main/java/sr/otaryp/tesatyla/data/lessons/LessonStepEntity.kt
@@ -1,0 +1,15 @@
+package sr.otaryp.tesatyla.data.lessons
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "lesson_steps")
+data class LessonStepEntity(
+    @PrimaryKey val id: Int,
+    val lessonId: Int,
+    val number: Int,
+    val title: String,
+    val theory: String,
+    val practice: String,
+    val isCompleted: Boolean = false
+)

--- a/app/src/main/java/sr/otaryp/tesatyla/data/lessons/LessonWithSteps.kt
+++ b/app/src/main/java/sr/otaryp/tesatyla/data/lessons/LessonWithSteps.kt
@@ -1,0 +1,13 @@
+package sr.otaryp.tesatyla.data.lessons
+
+import androidx.room.Embedded
+import androidx.room.Relation
+
+data class LessonWithSteps(
+    @Embedded val lesson: LessonEntity,
+    @Relation(
+        parentColumn = "id",
+        entityColumn = "lessonId"
+    )
+    val steps: List<LessonStepEntity>
+)

--- a/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/VictoryHallFragment.kt
+++ b/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/VictoryHallFragment.kt
@@ -1,50 +1,131 @@
 package sr.otaryp.tesatyla.presentation.ui
 
 import android.os.Bundle
-import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+import androidx.navigation.fragment.findNavController
+import androidx.navigation.fragment.navArgs
+import kotlinx.coroutines.launch
 import sr.otaryp.tesatyla.R
+import sr.otaryp.tesatyla.data.preferences.LessonProgressPreferences
+import sr.otaryp.tesatyla.databinding.FragmentVictoryHallBinding
 
-// TODO: Rename parameter arguments, choose names that match
-// the fragment initialization parameters, e.g. ARG_ITEM_NUMBER
-private const val ARG_PARAM1 = "param1"
-private const val ARG_PARAM2 = "param2"
-
-/**
- * A simple [Fragment] subclass.
- * Use the [VictoryHallFragment.newInstance] factory method to
- * create an instance of this fragment.
- */
 class VictoryHallFragment : Fragment() {
 
+    private val args: VictoryHallFragmentArgs by navArgs()
 
-    override fun onCreateView(
-        inflater: LayoutInflater, container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View? {
-        // Inflate the layout for this fragment
-        return inflater.inflate(R.layout.fragment_victory_hall, container, false)
+    private var _binding: FragmentVictoryHallBinding? = null
+    private val binding get() = _binding!!
+
+    private val viewModel: VictoryHallViewModel by viewModels {
+        VictoryHallViewModel.provideFactory(requireContext(), args.lessonId)
     }
 
-    companion object {
-        /**
-         * Use this factory method to create a new instance of
-         * this fragment using the provided parameters.
-         *
-         * @param param1 Parameter 1.
-         * @param param2 Parameter 2.
-         * @return A new instance of fragment VictoryHallFragment.
-         */
-        // TODO: Rename and change types and number of parameters
-        @JvmStatic
-        fun newInstance(param1: String, param2: String) =
-            VictoryHallFragment().apply {
-                arguments = Bundle().apply {
-                    putString(ARG_PARAM1, param1)
-                    putString(ARG_PARAM2, param2)
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = FragmentVictoryHallBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        setupToolbar()
+        setupButtons()
+        observeUiState()
+        observeEvents()
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+
+    private fun setupToolbar() {
+        binding.btnBack.setOnClickListener { findNavController().navigateUp() }
+    }
+
+    private fun setupButtons() {
+        binding.btnNextLesson.isEnabled = false
+        binding.btnReplayLesson.setOnClickListener {
+            viewModel.replayLesson()
+        }
+        binding.btnNextLesson.setOnClickListener {
+            val state = viewModel.uiState.value
+            val nextLessonId = state.nextLessonId
+            if (nextLessonId != null) {
+                val nextTitle = state.nextLessonTitle ?: state.lessonTitle
+                LessonProgressPreferences.setCurrentLesson(
+                    requireContext(),
+                    nextLessonId,
+                    nextTitle
+                )
+                val directions = VictoryHallFragmentDirections
+                    .actionVictoryHallFragmentToLessonDetailFragment(nextLessonId)
+                findNavController().navigate(directions)
+            } else {
+                LessonProgressPreferences.clear(requireContext())
+                findNavController().navigate(R.id.nav_lessons)
+            }
+        }
+    }
+
+    private fun observeUiState() {
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.uiState.collect { state ->
+                    val lessonTitle = state.lessonTitle
+                    val titleText = if (lessonTitle.isNotBlank()) {
+                        getString(R.string.victory_title_template, lessonTitle)
+                    } else {
+                        getString(R.string.victory_generic_title)
+                    }
+                    val messageText = if (lessonTitle.isNotBlank()) {
+                        getString(R.string.victory_message_template, lessonTitle)
+                    } else {
+                        getString(R.string.victory_generic_message)
+                    }
+                    binding.tvVictoryTitle.text = titleText
+                    binding.tvVictoryMessage.text = messageText
+
+                    if (state.nextLessonId != null && state.nextLessonTitle != null) {
+                        binding.btnNextLesson.isEnabled = true
+                        binding.btnNextLesson.text = getString(R.string.victory_next_lesson)
+                    } else {
+                        binding.btnNextLesson.isEnabled = false
+                        binding.btnNextLesson.text = getString(R.string.victory_no_next_lesson)
+                    }
                 }
             }
+        }
+    }
+
+    private fun observeEvents() {
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.events.collect { event ->
+                    when (event) {
+                        is VictoryHallEvent.LessonReset -> {
+                            LessonProgressPreferences.setCurrentLesson(
+                                requireContext(),
+                                event.lessonId,
+                                event.lessonTitle
+                            )
+                            val directions = VictoryHallFragmentDirections
+                                .actionVictoryHallFragmentToLessonDetailFragment(event.lessonId)
+                            findNavController().navigate(directions)
+                        }
+                    }
+                }
+            }
+        }
     }
 }

--- a/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/VictoryHallViewModel.kt
+++ b/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/VictoryHallViewModel.kt
@@ -1,0 +1,76 @@
+package sr.otaryp.tesatyla.presentation.ui
+
+import android.content.Context
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import sr.otaryp.tesatyla.data.lessons.LessonRepository
+
+class VictoryHallViewModel(
+    private val repository: LessonRepository,
+    private val lessonId: Int
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(VictoryHallUiState(lessonId = lessonId))
+    val uiState: StateFlow<VictoryHallUiState> = _uiState.asStateFlow()
+
+    private val _events = MutableSharedFlow<VictoryHallEvent>()
+    val events: SharedFlow<VictoryHallEvent> = _events.asSharedFlow()
+
+    init {
+        viewModelScope.launch {
+            val lesson = repository.getLessonById(lessonId)
+            val nextLessonId = repository.getNextLessonId(lessonId)
+            val nextLessonTitle = nextLessonId?.let { repository.getLessonById(it)?.title }
+            _uiState.value = VictoryHallUiState(
+                lessonId = lessonId,
+                lessonTitle = lesson?.title.orEmpty(),
+                nextLessonId = nextLessonId,
+                nextLessonTitle = nextLessonTitle
+            )
+        }
+    }
+
+    fun replayLesson() {
+        viewModelScope.launch {
+            repository.resetLesson(lessonId)
+            val lessonTitle = repository.getLessonById(lessonId)?.title
+                ?: _uiState.value.lessonTitle
+            _events.emit(VictoryHallEvent.LessonReset(lessonId, lessonTitle))
+        }
+    }
+
+    companion object {
+        fun provideFactory(context: Context, lessonId: Int): ViewModelProvider.Factory {
+            val appContext = context.applicationContext
+            return object : ViewModelProvider.Factory {
+                override fun <T : ViewModel> create(modelClass: Class<T>): T {
+                    val repository = LessonRepository.getInstance(appContext)
+                    if (modelClass.isAssignableFrom(VictoryHallViewModel::class.java)) {
+                        @Suppress("UNCHECKED_CAST")
+                        return VictoryHallViewModel(repository, lessonId) as T
+                    }
+                    throw IllegalArgumentException("Unknown ViewModel class")
+                }
+            }
+        }
+    }
+}
+
+data class VictoryHallUiState(
+    val lessonId: Int,
+    val lessonTitle: String = "",
+    val nextLessonId: Int? = null,
+    val nextLessonTitle: String? = null
+)
+
+sealed interface VictoryHallEvent {
+    data class LessonReset(val lessonId: Int, val lessonTitle: String) : VictoryHallEvent
+}

--- a/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/lessons/LessonDetailViewModel.kt
+++ b/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/lessons/LessonDetailViewModel.kt
@@ -1,0 +1,77 @@
+package sr.otaryp.tesatyla.presentation.ui.lessons
+
+import android.content.Context
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import sr.otaryp.tesatyla.data.lessons.LessonRepository
+
+class LessonDetailViewModel(
+    private val repository: LessonRepository,
+    private val lessonId: Int
+) : ViewModel() {
+
+    val uiState: StateFlow<LessonDetailUiState> = repository
+        .observeLesson(lessonId)
+        .map { lessonWithSteps ->
+            val lesson = lessonWithSteps.lesson
+            LessonDetailUiState(
+                lessonId = lesson.id,
+                title = lesson.title,
+                description = lesson.description,
+                teaching = lesson.teaching,
+                steps = lessonWithSteps.steps.sortedBy { it.number }.map { step ->
+                    LessonStepItem(
+                        id = step.id,
+                        lessonId = lesson.id,
+                        stepNumber = step.number,
+                        title = step.title,
+                        theoryPreview = step.theory.take(160),
+                        isCompleted = step.isCompleted
+                    )
+                }
+            )
+        }
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5_000),
+            initialValue = LessonDetailUiState(lessonId = lessonId)
+        )
+
+    companion object {
+        fun provideFactory(context: Context, lessonId: Int): ViewModelProvider.Factory {
+            val appContext = context.applicationContext
+            return object : ViewModelProvider.Factory {
+                override fun <T : ViewModel> create(modelClass: Class<T>): T {
+                    val repository = LessonRepository.getInstance(appContext)
+                    if (modelClass.isAssignableFrom(LessonDetailViewModel::class.java)) {
+                        @Suppress("UNCHECKED_CAST")
+                        return LessonDetailViewModel(repository, lessonId) as T
+                    }
+                    throw IllegalArgumentException("Unknown ViewModel class")
+                }
+            }
+        }
+    }
+}
+
+data class LessonDetailUiState(
+    val lessonId: Int,
+    val title: String = "",
+    val description: String = "",
+    val teaching: String = "",
+    val steps: List<LessonStepItem> = emptyList()
+)
+
+data class LessonStepItem(
+    val id: Int,
+    val lessonId: Int,
+    val stepNumber: Int,
+    val title: String,
+    val theoryPreview: String,
+    val isCompleted: Boolean
+)

--- a/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/lessons/LessonListViewModel.kt
+++ b/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/lessons/LessonListViewModel.kt
@@ -1,0 +1,51 @@
+package sr.otaryp.tesatyla.presentation.ui.lessons
+
+import android.content.Context
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import sr.otaryp.tesatyla.data.lessons.LessonRepository
+
+class LessonListViewModel(
+    private val repository: LessonRepository
+) : ViewModel() {
+
+    val lessons: StateFlow<List<LessonListItem>> = repository
+        .observeLessons()
+        .map { lessonWithSteps ->
+            lessonWithSteps.map { lesson ->
+                val entity = lesson.lesson
+                LessonListItem(
+                    id = entity.id,
+                    title = entity.title,
+                    description = entity.description,
+                    isCompleted = entity.isCompleted
+                )
+            }
+        }
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5_000),
+            initialValue = emptyList()
+        )
+
+    companion object {
+        fun provideFactory(context: Context): ViewModelProvider.Factory {
+            val appContext = context.applicationContext
+            return object : ViewModelProvider.Factory {
+                override fun <T : ViewModel> create(modelClass: Class<T>): T {
+                    val repository = LessonRepository.getInstance(appContext)
+                    if (modelClass.isAssignableFrom(LessonListViewModel::class.java)) {
+                        @Suppress("UNCHECKED_CAST")
+                        return LessonListViewModel(repository) as T
+                    }
+                    throw IllegalArgumentException("Unknown ViewModel class")
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/lessons/LessonStepDetailViewModel.kt
+++ b/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/lessons/LessonStepDetailViewModel.kt
@@ -1,0 +1,113 @@
+package sr.otaryp.tesatyla.presentation.ui.lessons
+
+import android.content.Context
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import sr.otaryp.tesatyla.data.lessons.LessonRepository
+import sr.otaryp.tesatyla.data.lessons.StepCompletionResult
+
+class LessonStepDetailViewModel(
+    private val repository: LessonRepository,
+    private val lessonId: Int,
+    private val stepId: Int
+) : ViewModel() {
+
+    private val eventsFlow = MutableSharedFlow<LessonStepDetailEvent>()
+    val events: SharedFlow<LessonStepDetailEvent> = eventsFlow
+
+    val uiState: StateFlow<LessonStepDetailUiState> = combine(
+        repository.observeStep(stepId),
+        repository.observeLesson(lessonId)
+    ) { step, lessonWithSteps ->
+        val lesson = lessonWithSteps.lesson
+        val remainingIncomplete = lessonWithSteps.steps.count { !it.isCompleted }
+        LessonStepDetailUiState(
+            lessonId = lesson.id,
+            lessonTitle = lesson.title,
+            stepId = step.id,
+            stepNumber = step.number,
+            stepTitle = step.title,
+            theory = step.theory,
+            practice = step.practice,
+            isCompleted = step.isCompleted,
+            isLastIncompleteStep = !step.isCompleted && remainingIncomplete <= 1
+        )
+    }.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(5_000),
+        initialValue = LessonStepDetailUiState(lessonId = lessonId, stepId = stepId)
+    )
+
+    fun onCompleteStep() {
+        viewModelScope.launch {
+            when (repository.completeStep(lessonId, stepId)) {
+                StepCompletionResult.StepCompleted ->
+                    eventsFlow.emit(LessonStepDetailEvent.StepCompleted)
+
+                StepCompletionResult.LessonCompleted -> {
+                    val nextLessonId = repository.getNextLessonId(lessonId)
+                    val nextLessonTitle = nextLessonId?.let { repository.getLessonById(it)?.title }
+                    val currentLessonTitle = uiState.value.lessonTitle
+                    eventsFlow.emit(
+                        LessonStepDetailEvent.LessonCompleted(
+                            lessonId = lessonId,
+                            lessonTitle = currentLessonTitle,
+                            nextLessonId = nextLessonId,
+                            nextLessonTitle = nextLessonTitle
+                        )
+                    )
+                }
+            }
+        }
+    }
+
+    companion object {
+        fun provideFactory(
+            context: Context,
+            lessonId: Int,
+            stepId: Int
+        ): ViewModelProvider.Factory {
+            val appContext = context.applicationContext
+            return object : ViewModelProvider.Factory {
+                override fun <T : ViewModel> create(modelClass: Class<T>): T {
+                    val repository = LessonRepository.getInstance(appContext)
+                    if (modelClass.isAssignableFrom(LessonStepDetailViewModel::class.java)) {
+                        @Suppress("UNCHECKED_CAST")
+                        return LessonStepDetailViewModel(repository, lessonId, stepId) as T
+                    }
+                    throw IllegalArgumentException("Unknown ViewModel class")
+                }
+            }
+        }
+    }
+}
+
+data class LessonStepDetailUiState(
+    val lessonId: Int,
+    val lessonTitle: String = "",
+    val stepId: Int,
+    val stepNumber: Int = 0,
+    val stepTitle: String = "",
+    val theory: String = "",
+    val practice: String = "",
+    val isCompleted: Boolean = false,
+    val isLastIncompleteStep: Boolean = false
+)
+
+sealed interface LessonStepDetailEvent {
+    object StepCompleted : LessonStepDetailEvent
+    data class LessonCompleted(
+        val lessonId: Int,
+        val lessonTitle: String,
+        val nextLessonId: Int?,
+        val nextLessonTitle: String?
+    ) : LessonStepDetailEvent
+}

--- a/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/lessons/LessonStepsAdapter.kt
+++ b/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/lessons/LessonStepsAdapter.kt
@@ -1,0 +1,57 @@
+package sr.otaryp.tesatyla.presentation.ui.lessons
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import sr.otaryp.tesatyla.R
+import sr.otaryp.tesatyla.databinding.LesssonStepItemBinding
+
+class LessonStepsAdapter(
+    private val onStepSelected: (LessonStepItem) -> Unit
+) : ListAdapter<LessonStepItem, LessonStepsAdapter.StepViewHolder>(DiffCallback) {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): StepViewHolder {
+        val binding = LesssonStepItemBinding.inflate(
+            LayoutInflater.from(parent.context),
+            parent,
+            false
+        )
+        return StepViewHolder(binding)
+    }
+
+    override fun onBindViewHolder(holder: StepViewHolder, position: Int) {
+        holder.bind(getItem(position), onStepSelected)
+    }
+
+    class StepViewHolder(
+        private val binding: LesssonStepItemBinding
+    ) : RecyclerView.ViewHolder(binding.root) {
+
+        fun bind(item: LessonStepItem, onStepSelected: (LessonStepItem) -> Unit) {
+            binding.tvStepTitle.text = item.title
+            binding.tvStepPreview.text = item.theoryPreview
+
+            if (item.isCompleted) {
+                binding.tvStepStatus.visibility = View.VISIBLE
+                binding.tvStepStatus.setText(R.string.lesson_step_completed)
+                binding.btnOpenStep.setText(R.string.lesson_step_review)
+            } else {
+                binding.tvStepStatus.visibility = View.GONE
+                binding.btnOpenStep.setText(R.string.lesson_step_open)
+            }
+
+            binding.btnOpenStep.setOnClickListener { onStepSelected(item) }
+        }
+    }
+
+    private object DiffCallback : DiffUtil.ItemCallback<LessonStepItem>() {
+        override fun areItemsTheSame(oldItem: LessonStepItem, newItem: LessonStepItem): Boolean =
+            oldItem.id == newItem.id
+
+        override fun areContentsTheSame(oldItem: LessonStepItem, newItem: LessonStepItem): Boolean =
+            oldItem == newItem
+    }
+}

--- a/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/main/HomeFragment.kt
+++ b/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/main/HomeFragment.kt
@@ -10,6 +10,7 @@ import androidx.appcompat.app.AlertDialog
 
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
+import sr.otaryp.tesatyla.presentation.ui.main.HomeFragmentDirections
 import sr.otaryp.tesatyla.R
 import sr.otaryp.tesatyla.data.content.InspirationRepository
 import sr.otaryp.tesatyla.data.preferences.LessonProgressPreferences
@@ -55,7 +56,9 @@ class HomeFragment : Fragment() {
             val navController = findNavController()
             val lessonProgress = LessonProgressPreferences.getCurrentLesson(requireContext())
             if (lessonProgress != null) {
-                navController.navigate(R.id.action_nav_home_to_lessonDetailFragment)
+                val directions = HomeFragmentDirections
+                    .actionNavHomeToLessonDetailFragment(lessonProgress.lessonId)
+                navController.navigate(directions)
             } else {
                 navController.navigate(R.id.action_nav_home_to_nav_lessons)
             }

--- a/app/src/main/res/layout/fragment_lesson_detail.xml
+++ b/app/src/main/res/layout/fragment_lesson_detail.xml
@@ -1,65 +1,113 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@drawable/lesson_fragment_bg"
+    android:paddingBottom="24dp"
     tools:context=".presentation.ui.lessons.LessonDetailFragment">
 
     <LinearLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
+        android:layout_height="wrap_content"
         android:orientation="vertical">
-
 
         <FrameLayout
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:paddingTop="30dp">
+            android:layout_height="wrap_content"
+            android:paddingHorizontal="20dp"
+            android:paddingTop="30dp"
+            android:paddingBottom="16dp">
 
             <TextView
                 android:id="@+id/btnBack"
+                style="@style/TextAppearance.AppCompat.Title"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_marginStart="20dp"
-                android:text="Back"
-                android:textColor="@color/white"
-                android:textSize="20sp" />
-
-            <ImageView
-                android:layout_width="50dp"
-                android:layout_height="50dp"
-                android:layout_gravity="end"
-                android:layout_marginEnd="20dp"
-                android:src="@drawable/settings_bg" />
+                android:text="@string/lesson_back"
+                android:textColor="@color/white" />
 
             <TextView
+                android:id="@+id/tvLessonTitle"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_gravity="bottom|center"
-                android:layout_marginTop="20dp"
+                android:layout_gravity="center_horizontal"
+                android:fontFamily="@font/inter_18pt_bold"
                 android:gravity="center"
-                android:layout_marginBottom="10dp"
-                android:paddingTop="20dp"
-                android:text="Lesson 1:\nPomodoro trials"
-                android:textSize="25sp" />
-
-
+                android:textColor="@color/white"
+                android:textSize="22sp"
+                tools:text="Lesson 1: Pomodoro Trials" />
         </FrameLayout>
 
         <ImageView
             android:id="@+id/illustration"
             android:layout_width="match_parent"
-            android:layout_height="255dp"
-            android:src="@drawable/quest_photo" />
+            android:layout_height="220dp"
+            android:adjustViewBounds="true"
+            android:scaleType="centerCrop"
+            android:src="@drawable/quest_photo"
+            android:contentDescription="@null" />
 
-        <androidx.recyclerview.widget.RecyclerView
+        <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            tools:listitem="@layout/lessson_step_item"
-            android:layout_marginHorizontal="20dp"/>
+            android:layout_marginHorizontal="20dp"
+            android:layout_marginTop="16dp"
+            android:background="@drawable/steps_bg_im"
+            android:orientation="vertical"
+            android:padding="20dp">
+
+            <TextView
+                android:id="@+id/tvLessonDescription"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:fontFamily="@font/inter_18pt_medium"
+                android:textColor="@color/white"
+                android:textSize="14sp"
+                tools:text="Train in timed battles: 25 minutes of focus, 5 minutes of rest." />
+        </LinearLayout>
+
+        <TextView
+            android:id="@+id/tvLessonTeachingLabel"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="20dp"
+            android:layout_marginTop="20dp"
+            android:fontFamily="@font/inter_18pt_bold"
+            android:text="@string/lesson_teaches_label"
+            android:textColor="@color/white"
+            android:textSize="18sp" />
+
+        <TextView
+            android:id="@+id/tvLessonTeaching"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="20dp"
+            android:layout_marginTop="8dp"
+            android:fontFamily="@font/inter_18pt_regular"
+            android:textColor="@color/white"
+            android:textSize="14sp"
+            tools:text="This lesson introduces you to the Pomodoro Technique — a method to increase focus and avoid burnout." />
+
+        <TextView
+            android:id="@+id/tvStepsTitle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="20dp"
+            android:layout_marginTop="24dp"
+            android:fontFamily="@font/inter_18pt_bold"
+            android:text="@string/lesson_steps_title"
+            android:textColor="@color/white"
+            android:textSize="18sp" />
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/rvSteps"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="20dp"
+            android:layout_marginTop="12dp"
+            android:nestedScrollingEnabled="false"
+            tools:listitem="@layout/lessson_step_item" />
     </LinearLayout>
-
-
-
 </ScrollView>

--- a/app/src/main/res/layout/fragment_lesson_step_detail.xml
+++ b/app/src/main/res/layout/fragment_lesson_step_detail.xml
@@ -5,107 +5,129 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@drawable/lesson_fragment_bg"
+    android:paddingBottom="24dp"
     tools:context=".presentation.ui.lessons.LessonStepDetailFragment">
 
     <LinearLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
+        android:layout_height="wrap_content"
         android:orientation="vertical">
-
-
-        <FrameLayout
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:paddingTop="30dp">
-
-            <TextView
-                android:id="@+id/btnBack"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="20dp"
-                android:text="Back"
-                android:textColor="@color/white"
-                android:textSize="20sp" />
-
-            <ImageView
-                android:layout_width="50dp"
-                android:layout_height="50dp"
-                android:layout_gravity="end"
-                android:layout_marginEnd="20dp"
-                android:src="@drawable/settings_bg" />
-
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="bottom|center"
-                android:layout_marginTop="20dp"
-                android:layout_marginBottom="10dp"
-                android:gravity="center"
-                android:paddingTop="20dp"
-                android:text="Lesson 1:\nPomodoro trials"
-                android:textSize="25sp" />
-
-
-        </FrameLayout>
-
-        <View
-            android:id="@+id/goldDivider"
-            android:layout_width="match_parent"
-            android:layout_height="2dp"
-            android:layout_marginTop="10dp"
-            android:background="@drawable/gradient_view"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
 
         <FrameLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginTop="10dp">
+            android:paddingHorizontal="20dp"
+            android:paddingTop="30dp"
+            android:paddingBottom="16dp">
+
+            <TextView
+                android:id="@+id/btnBack"
+                style="@style/TextAppearance.AppCompat.Title"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/lesson_back"
+                android:textColor="@color/white" />
+
+            <TextView
+                android:id="@+id/tvLessonTitle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_horizontal"
+                android:fontFamily="@font/inter_18pt_bold"
+                android:gravity="center"
+                android:textColor="@color/white"
+                android:textSize="22sp"
+                tools:text="Lesson 1: Pomodoro Trials" />
+        </FrameLayout>
+
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="2dp"
+            android:background="@drawable/gradient_view" />
+
+        <FrameLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="20dp"
+            android:layout_marginHorizontal="20dp">
 
             <ImageView
                 android:layout_width="match_parent"
-                android:layout_height="280dp"
-                android:src="@drawable/steps_bg" />
-
+                android:layout_height="240dp"
+                android:adjustViewBounds="true"
+                android:scaleType="centerCrop"
+                android:src="@drawable/steps_bg"
+                android:contentDescription="@null" />
 
             <TextView
+                android:id="@+id/tvStepTitle"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_gravity="center|top"
+                android:layout_gravity="center_horizontal|top"
                 android:layout_marginTop="40dp"
-                android:text="Step 1:"
-                android:textSize="20sp" />
-
+                android:fontFamily="@font/inter_18pt_bold"
+                android:gravity="center"
+                android:textColor="@color/white"
+                android:textSize="18sp"
+                tools:text="Step 1: Learn the 25–5 Pomodoro structure" />
         </FrameLayout>
 
         <LinearLayout
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:layout_marginHorizontal="25dp"
-            android:layout_marginTop="10dp"
-            android:background="@drawable/steps_bg_im">
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="20dp"
+            android:layout_marginTop="16dp"
+            android:background="@drawable/steps_bg_im"
+            android:orientation="vertical"
+            android:padding="20dp">
 
             <TextView
+                android:id="@+id/tvTheoryLabel"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                android:fontFamily="@font/inter_18pt_bold"
+                android:text="@string/lesson_step_theory"
+                android:textColor="@color/white"
+                android:textSize="16sp" />
+
+            <TextView
+                android:id="@+id/tvTheory"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
                 android:fontFamily="@font/inter_18pt_regular"
-                android:paddingHorizontal="20dp"
-                android:text=" Theory: The Pomodoro method divides work into cycles of 25 minutes of focused work followed by 5 minutes of rest. These short sprints allow the brain to recharge regularly, preventing fatigue and increasing concentration. Long, uninterrupted work sessions often reduce effectiveness over time.  Practice: Read about the Pomodoro cycle. Write down the structure somewhere visible: 25 minutes work → 5 minutes rest → repeat 4 times → then a longer break of 15–30 minutes."
-                android:textColor="#DCFFFFFF"
-                android:textSize="14sp" />
+                android:textColor="@color/white"
+                android:textSize="14sp"
+                tools:text="The Pomodoro method divides work into cycles of 25 minutes of focused work followed by 5 minutes of rest." />
 
-        </LinearLayout>
-
-        <androidx.appcompat.widget.AppCompatButton
-            android:id="@+id/btnCompleteQuest"
-            android:layout_width="wrap_content"
-            android:text="Complete the quest"
+            <TextView
+                android:id="@+id/tvPracticeLabel"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="20dp"
+                android:fontFamily="@font/inter_18pt_bold"
+                android:text="@string/lesson_step_practice"
+                android:textColor="@color/white"
+                android:textSize="16sp" />
+            <TextView
+                android:id="@+id/tvPractice"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:fontFamily="@font/inter_18pt_regular"
+                android:textColor="@color/white"
+                android:textSize="14sp"
+                tools:text="Read about the Pomodoro cycle. Write down the structure somewhere visible." />
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_horizontal"
+            android:layout_marginTop="24dp"
+            android:paddingHorizontal="28dp"
+            android:paddingVertical="12dp"
+            android:text="@string/lesson_step_complete"
+            android:textAllCaps="false"
             android:textColor="@color/white"
-            android:layout_gravity="center"
-            android:layout_marginTop="10dp"
-            android:textAllCaps="true"
+            android:textSize="16sp" />
+</ScrollView>
             android:paddingHorizontal="20dp"
             android:letterSpacing="0.1"
             android:layout_marginBottom="10dp"

--- a/app/src/main/res/layout/fragment_victory_hall.xml
+++ b/app/src/main/res/layout/fragment_victory_hall.xml
@@ -9,29 +9,28 @@
 
     <ScrollView
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
+        android:layout_height="match_parent"
+        android:paddingBottom="120dp">
 
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="vertical">
 
-
-            <!-- Header: фиолетовый фон только сверху -->
             <FrameLayout
                 android:id="@+id/header"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:background="#420840"
                 android:paddingTop="30dp"
-                android:paddingBottom="12dp">
+                android:paddingBottom="16dp"
+                android:paddingHorizontal="20dp">
 
                 <TextView
                     android:id="@+id/btnBack"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_marginStart="20dp"
-                    android:text="Back"
+                    android:text="@string/lesson_back"
                     android:textColor="@color/white"
                     android:textSize="20sp" />
             </FrameLayout>
@@ -40,40 +39,63 @@
                 android:id="@+id/goldDivider"
                 android:layout_width="match_parent"
                 android:layout_height="2dp"
-                android:background="@drawable/gradient_view"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent" />
+                android:background="@drawable/gradient_view" />
 
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="24dp"
+                android:layout_marginTop="32dp"
+                android:background="@drawable/steps_bg_im"
+                android:orientation="vertical"
+                android:padding="24dp">
+
+                <TextView
+                    android:id="@+id/tvVictoryTitle"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:fontFamily="@font/inter_18pt_bold"
+                    android:gravity="center"
+                    android:textColor="@color/white"
+                    android:textSize="20sp"
+                    tools:text="Victory Achieved!" />
+
+                <TextView
+                    android:id="@+id/tvVictoryMessage"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="12dp"
+                    android:fontFamily="@font/inter_18pt_regular"
+                    android:gravity="center"
+                    android:textColor="@color/white"
+                    android:textSize="14sp"
+                    tools:text="You have completed Pomodoro Trials. The kingdom applauds your focus!" />
+            </LinearLayout>
         </LinearLayout>
     </ScrollView>
-
 
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:gravity="center"
-        android:layout_marginBottom="40dp"
         android:layout_gravity="bottom"
+        android:layout_marginBottom="32dp"
+        android:gravity="center"
         android:orientation="vertical"
         android:padding="16dp">
 
-        <!-- Next Lesson Button -->
         <androidx.appcompat.widget.AppCompatButton
             android:id="@+id/btnNextLesson"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginBottom="25dp"
+            android:layout_marginBottom="20dp"
             android:background="@drawable/next_button_bg"
             android:fontFamily="@font/inter_18pt_extrabold"
             android:minWidth="200dp"
             android:paddingHorizontal="30dp"
-            android:text="Next Lesson"
+            android:text="@string/victory_next_lesson"
             android:textColor="#FFFFFF"
             android:textSize="16sp" />
 
-        <!-- Replay Lesson Button -->
         <androidx.appcompat.widget.AppCompatButton
             android:id="@+id/btnReplayLesson"
             android:layout_width="wrap_content"
@@ -82,12 +104,8 @@
             android:fontFamily="@font/inter_18pt_extrabold"
             android:minWidth="200dp"
             android:paddingHorizontal="30dp"
-            android:text="Replay Lesson"
+            android:text="@string/victory_replay_lesson"
             android:textColor="#FFFFFF"
             android:textSize="16sp" />
-
     </LinearLayout>
-
-
-
 </FrameLayout>

--- a/app/src/main/res/layout/lessson_step_item.xml
+++ b/app/src/main/res/layout/lessson_step_item.xml
@@ -1,49 +1,72 @@
-<FrameLayout android:layout_width="match_parent"
-    android:layout_height="185dp"
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:layout_marginTop="15dp"
-    xmlns:android="http://schemas.android.com/apk/res/android">
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginTop="16dp">
 
     <LinearLayout
         android:layout_width="match_parent"
-        android:layout_height="160dp"
+        android:layout_height="wrap_content"
         android:background="@drawable/list_with_quests"
+        android:minHeight="170dp"
         android:orientation="vertical"
-        android:padding="40dp">
+        android:paddingHorizontal="32dp"
+        android:paddingVertical="28dp">
 
         <TextView
-            android:layout_width="wrap_content"
+            android:id="@+id/tvStepTitle"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_gravity="center"
             android:fontFamily="@font/inter_18pt_bold"
             android:gravity="center"
-            android:text="Step 1: Learn the 25–5 Pomodoro\nstructure"
             android:textColor="#511300"
-            android:textSize="15sp" />
+            android:textSize="16sp"
+            tools:text="Step 1: Learn the 25–5 Pomodoro structure" />
 
         <TextView
+            android:id="@+id/tvStepPreview"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            android:gravity="center"
+            android:textColor="#511300"
+            android:textSize="13sp"
+            tools:text="Theory: The Pomodoro method divides work into cycles of 25 minutes of focused work followed by 5 minutes of rest..." />
+
+        <TextView
+            android:id="@+id/tvStepStatus"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_gravity="center"
-            android:gravity="center"
-            android:text="Theory: The Pomodoro method divides work into cycles of 25 minutes ..." />
-
-
+            android:layout_gravity="center_horizontal"
+            android:layout_marginTop="12dp"
+            android:background="@drawable/btn_enter_kingdom1"
+            android:fontFamily="@font/inter_18pt_medium"
+            android:paddingHorizontal="16dp"
+            android:paddingVertical="6dp"
+            android:textColor="#FFE08A"
+            android:textSize="12sp"
+            android:textStyle="bold"
+            android:visibility="gone"
+            tools:text="Completed"
+            tools:visibility="visible" />
     </LinearLayout>
 
     <androidx.appcompat.widget.AppCompatButton
-        android:id="@+id/btnNextT2"
+        android:id="@+id/btnOpenStep"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="bottom|center"
+        android:layout_marginBottom="12dp"
         android:background="@drawable/btn_enter_kingdom1"
         android:minWidth="160dp"
         android:minHeight="0dp"
         android:paddingHorizontal="30dp"
         android:paddingVertical="14dp"
-        android:text="Continue"
+        android:text="@string/lesson_step_open"
         android:textAllCaps="false"
         android:textColor="#FFE08A"
-        android:textSize="18sp"
+        android:textSize="16sp"
         android:textStyle="bold" />
 </FrameLayout>

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -54,7 +54,11 @@
         android:id="@+id/nav_lessons"
         android:name="sr.otaryp.tesatyla.presentation.ui.lessons.LessonListFragment"
         android:label="Lessons"
-        tools:layout="@layout/fragment_lesson_list" />
+        tools:layout="@layout/fragment_lesson_list">
+        <action
+            android:id="@+id/action_nav_lessons_to_lessonDetailFragment"
+            app:destination="@id/lessonDetailFragment" />
+    </fragment>
 
     <fragment
         android:id="@+id/nav_articles"
@@ -78,13 +82,47 @@
         android:id="@+id/lessonDetailFragment"
         android:name="sr.otaryp.tesatyla.presentation.ui.lessons.LessonDetailFragment"
         android:label="Lesson Detail"
-        tools:layout="@layout/fragment_lesson_detail" />
+        tools:layout="@layout/fragment_lesson_detail">
+        <argument
+            android:name="lessonId"
+            app:argType="integer" />
+        <action
+            android:id="@+id/action_lessonDetailFragment_to_lessonStepDetailFragment"
+            app:destination="@id/lessonStepDetailFragment" />
+    </fragment>
 
     <fragment
         android:id="@+id/lessonStepDetailFragment"
         android:name="sr.otaryp.tesatyla.presentation.ui.lessons.LessonStepDetailFragment"
         android:label="Lesson Step Detail"
-        tools:layout="@layout/fragment_lesson_step_detail" />
+        tools:layout="@layout/fragment_lesson_step_detail">
+        <argument
+            android:name="lessonId"
+            app:argType="integer" />
+        <argument
+            android:name="stepId"
+            app:argType="integer" />
+        <action
+            android:id="@+id/action_lessonStepDetailFragment_to_victoryHallFragment"
+            app:destination="@id/victoryHallFragment"
+            app:popUpTo="@id/lessonDetailFragment"
+            app:popUpToInclusive="true" />
+    </fragment>
+
+    <fragment
+        android:id="@+id/victoryHallFragment"
+        android:name="sr.otaryp.tesatyla.presentation.ui.VictoryHallFragment"
+        android:label="Victory Hall"
+        tools:layout="@layout/fragment_victory_hall">
+        <argument
+            android:name="lessonId"
+            app:argType="integer" />
+        <action
+            android:id="@+id/action_victoryHallFragment_to_lessonDetailFragment"
+            app:destination="@id/lessonDetailFragment"
+            app:popUpTo="@id/victoryHallFragment"
+            app:popUpToInclusive="true" />
+    </fragment>
 
     <fragment
         android:id="@+id/articleDetailFragment"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -32,6 +32,23 @@ Your quests await.</string>
 
     <string name="lesson_action_continue">Continue Quest</string>
     <string name="lesson_action_review">Review Quest</string>
+    <string name="lesson_back">Back</string>
+    <string name="lesson_teaches_label">What it teaches</string>
+    <string name="lesson_steps_title">Quest Steps</string>
+    <string name="lesson_step_open">Open step</string>
+    <string name="lesson_step_review">Review step</string>
+    <string name="lesson_step_completed">Completed</string>
+    <string name="lesson_step_theory">Theory</string>
+    <string name="lesson_step_practice">Practice</string>
+    <string name="lesson_step_complete">Complete quest</string>
+    <string name="lesson_step_completed_button">Quest completed</string>
+    <string name="victory_next_lesson">Next Lesson</string>
+    <string name="victory_replay_lesson">Replay Lesson</string>
+    <string name="victory_title_template">Victory! %1$s completed</string>
+    <string name="victory_message_template">You finished every step of %1$s. The kingdom celebrates your discipline!</string>
+    <string name="victory_generic_title">Victory!</string>
+    <string name="victory_generic_message">You completed this royal quest. Celebrate your progress!</string>
+    <string name="victory_no_next_lesson">All quests complete</string>
     <string name="lesson_title_pomodoro_trials">Pomodoro Trials</string>
     <string name="lesson_description_pomodoro_trials">Train in timed battles: 25 minutes of focus, 5 minutes of rest.</string>
     <string name="lesson_title_scrolls_of_order">Scrolls of Order</string>


### PR DESCRIPTION
## Summary
- seed a Room database with the lesson catalogue, detailed steps, and repository helpers for progress tracking
- connect the lesson list, detail, step, and victory flows to database-backed view models and a new step adapter
- refresh layouts, navigation graph, and strings so lessons show dynamic content, completion status, and victory handling

## Testing
- `./gradlew :app:assembleDebug` *(fails: Android SDK is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68de70a210f4832ab823526b5972e888