### PR TITLE
Fix lesson list layout to display seeded lessons

### DIFF
--- a/app/src/main/res/layout/fragment_lesson_list.xml
+++ b/app/src/main/res/layout/fragment_lesson_list.xml
@@ -1,77 +1,66 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@drawable/lesson_fragment_bg"
-    android:orientation="vertical"
     tools:context=".presentation.ui.lessons.LessonListFragment">
 
-    <LinearLayout
-        android:layout_width="match_parent"
+    <FrameLayout
+        android:id="@+id/header"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:orientation="vertical">
+        android:background="#420840"
+        android:paddingTop="30dp"
+        android:paddingBottom="12dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
 
-        <!-- Header: фиолетовый фон только сверху -->
-        <FrameLayout
-            android:id="@+id/header"
-            android:layout_width="match_parent"
+        <TextView
+            android:id="@+id/btnBack"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:background="#420840"
-            android:paddingTop="30dp"
-            android:paddingBottom="12dp">
+            android:layout_marginStart="20dp"
+            android:text="Back"
+            android:textColor="@color/white"
+            android:textSize="20sp" />
+    </FrameLayout>
 
-            <TextView
-                android:id="@+id/btnBack"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="20dp"
-                android:text="Back"
-                android:textColor="@color/white"
-                android:textSize="20sp" />
-        </FrameLayout>
+    <View
+        android:id="@+id/goldDivider"
+        android:layout_width="0dp"
+        android:layout_height="2dp"
+        android:background="@drawable/gradient_view"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/header" />
 
+    <TextView
+        android:id="@+id/tvContinueLesson"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="20dp"
+        android:layout_marginTop="15dp"
+        android:fontFamily="@font/inter_18pt_bold"
+        android:text="Continue Lesson"
+        android:textSize="22sp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/goldDivider" />
 
-            <View
-                android:id="@+id/goldDivider"
-                android:layout_width="match_parent"
-                android:layout_height="2dp"
-                android:background="@drawable/gradient_view"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toTopOf="parent"
-                app:layout_constraintBottom_toBottomOf="parent" />
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/rvListLessons"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:layout_marginHorizontal="20dp"
+        android:layout_marginTop="12dp"
+        android:paddingBottom="16dp"
+        android:clipToPadding="false"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/tvContinueLesson"
+        tools:itemCount="5" />
 
-
-<!--                <ImageView-->
-<!--                    android:id="@+id/ivSettings"-->
-<!--                    android:layout_width="match_parent"-->
-<!--                    android:layout_height="match_parent"-->
-<!--                    android:src="@drawable/ic_settings"-->
-<!--                   android:scaleType="centerInside" />-->
-
-        <!-- Контент -->
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginHorizontal="20dp"
-            android:orientation="vertical">
-
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginVertical="15dp"
-                android:fontFamily="@font/inter_18pt_bold"
-                android:text="Continue Lesson"
-                android:textSize="22sp" />
-
-            <androidx.recyclerview.widget.RecyclerView
-                android:id="@+id/rvListLessons"
-                tools:itemCount="20"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"/>
-
-        </LinearLayout>
-    </LinearLayout>
-</ScrollView>
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
## Summary
- replace the ScrollView-based lesson list layout with a ConstraintLayout structure
- give the lessons RecyclerView full screen constraints so seeded lessons can render correctly

## Testing
- `./gradlew assembleDebug` *(fails: Android SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68deb60cc388832aa75d08c9d71eda9e