### PR TITLE
Update lesson list logic for royal quest interactions

### DIFF
--- a/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/lessons/LessonAdapter.kt
+++ b/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/lessons/LessonAdapter.kt
@@ -37,13 +37,14 @@ class LessonAdapter(
             binding.levelIm.setImageResource(iconRes)
 
             val buttonTextRes = if (item.isCompleted) {
-                R.string.lesson_action_review
+                R.string.lesson_action_repeat
             } else {
                 R.string.lesson_action_continue
             }
             binding.btnContinue.setText(buttonTextRes)
 
             binding.btnContinue.setOnClickListener { onLessonSelected(item) }
+            binding.root.setOnClickListener { onLessonSelected(item) }
         }
     }
 

--- a/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/lessons/LessonListViewModel.kt
+++ b/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/lessons/LessonListViewModel.kt
@@ -21,7 +21,7 @@ class LessonListViewModel(
                 val entity = lesson.lesson
                 LessonListItem(
                     id = entity.id,
-                    title = entity.title,
+                    title = entity.title.replaceFirst(LESSON_TITLE_PREFIX_REGEX, "").trim(),
                     description = entity.description,
                     isCompleted = entity.isCompleted
                 )
@@ -34,6 +34,8 @@ class LessonListViewModel(
         )
 
     companion object {
+        private val LESSON_TITLE_PREFIX_REGEX = Regex("^Lesson \\d+:\\s*")
+
         fun provideFactory(context: Context): ViewModelProvider.Factory {
             val appContext = context.applicationContext
             return object : ViewModelProvider.Factory {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -31,7 +31,7 @@ Your quests await.</string>
     <string name="article_back">Back</string>
 
     <string name="lesson_action_continue">Continue Quest</string>
-    <string name="lesson_action_review">Review Quest</string>
+    <string name="lesson_action_repeat">Repeat Challenge</string>
     <string name="lesson_back">Back</string>
     <string name="lesson_teaches_label">What it teaches</string>
     <string name="lesson_steps_title">Quest Steps</string>


### PR DESCRIPTION
## Summary
- strip the numeric prefix from lesson titles before displaying them in the list
- allow tapping anywhere on a lesson card to open its details while keeping the continue button wired up
- rename the completed-lesson action to "Repeat Challenge" to match the royal quest copy

## Testing
- `./gradlew test` *(fails: Android SDK not configured in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68deca1f2d10832aba7ac47fca7d22b2