### PR TITLE
Enforce sequential progression on LessonDetailScreen

### DIFF
--- a/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/lessons/LessonDetailFragment.kt
+++ b/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/lessons/LessonDetailFragment.kt
@@ -107,6 +107,7 @@ class LessonDetailFragment : Fragment() {
                         state.totalSteps
                     )
                     val hasSteps = state.totalSteps > 0
+                    val hasAccessibleStep = state.steps.any { !it.isLocked && !it.isCompleted }
                     binding.tvLessonProgress.isVisible = hasSteps
                     binding.progressContainer.isVisible = hasSteps
                     binding.btnLessonCta.setText(
@@ -116,7 +117,8 @@ class LessonDetailFragment : Fragment() {
                             R.string.lesson_detail_cta_complete
                         }
                     )
-                    binding.btnLessonCta.isEnabled = hasSteps
+                    binding.btnLessonCta.isEnabled = state.isCompleted || hasAccessibleStep
+                    binding.btnLessonCta.alpha = if (state.isCompleted || hasAccessibleStep) 1f else 0.6f
                     stepsAdapter.submitList(state.steps)
 
                     LessonProgressPreferences.setCurrentLesson(
@@ -130,6 +132,7 @@ class LessonDetailFragment : Fragment() {
     }
 
     private fun onStepSelected(step: LessonStepItem) {
+        if (step.isLocked) return
         val directions = LessonDetailFragmentDirections
             .actionLessonDetailFragmentToLessonStepDetailFragment(
                 lessonId = step.lessonId,

--- a/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/lessons/LessonDetailViewModel.kt
+++ b/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/lessons/LessonDetailViewModel.kt
@@ -19,16 +19,19 @@ class LessonDetailViewModel(
         .observeLesson(lessonId)
         .map { lessonWithSteps ->
             val lesson = lessonWithSteps.lesson
-            val stepItems = lessonWithSteps.steps
-                .sortedBy { it.number }
-                .map { step ->
+            val sortedSteps = lessonWithSteps.steps.sortedBy { it.number }
+            val firstIncompleteIndex = sortedSteps.indexOfFirst { !it.isCompleted }
+            val stepItems = sortedSteps
+                .mapIndexed { index, step ->
+                    val isLocked = !step.isCompleted && firstIncompleteIndex != -1 && index > firstIncompleteIndex
                     LessonStepItem(
                         id = step.id,
                         lessonId = lesson.id,
                         stepNumber = step.number,
                         title = step.title,
                         theoryPreview = step.theory.take(160),
-                        isCompleted = step.isCompleted
+                        isCompleted = step.isCompleted,
+                        isLocked = isLocked
                     )
                 }
             val completedSteps = stepItems.count { it.isCompleted }
@@ -83,5 +86,6 @@ data class LessonStepItem(
     val stepNumber: Int,
     val title: String,
     val theoryPreview: String,
-    val isCompleted: Boolean
+    val isCompleted: Boolean,
+    val isLocked: Boolean
 )

--- a/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/lessons/LessonStepsAdapter.kt
+++ b/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/lessons/LessonStepsAdapter.kt
@@ -37,28 +37,58 @@ class LessonStepsAdapter(
             binding.tvStepTitle.text = item.title
             binding.tvStepPreview.text = item.theoryPreview
 
-            if (item.isCompleted) {
-                binding.tvStepStatus.visibility = View.VISIBLE
-                binding.tvStepStatus.setText(R.string.lesson_step_completed)
-                binding.btnStepAction.setText(R.string.lesson_step_review)
-                binding.ivStepStatus.setImageResource(R.drawable.shield_bg)
-                binding.cardContainer.setCardBackgroundColor(
-                    ContextCompat.getColor(context, R.color.step_card_background_completed)
-                )
-                binding.cardContainer.strokeColor =
-                    ContextCompat.getColor(context, R.color.step_card_stroke_completed)
-            } else {
-                binding.tvStepStatus.visibility = View.GONE
-                binding.btnStepAction.setText(R.string.lesson_step_open)
-                binding.ivStepStatus.setImageResource(R.drawable.shield_gray)
-                binding.cardContainer.setCardBackgroundColor(
-                    ContextCompat.getColor(context, R.color.step_card_background)
-                )
-                binding.cardContainer.strokeColor =
-                    ContextCompat.getColor(context, R.color.step_card_stroke)
+            when {
+                item.isCompleted -> {
+                    binding.tvStepStatus.visibility = View.VISIBLE
+                    binding.tvStepStatus.setText(R.string.lesson_step_completed)
+                    binding.btnStepAction.setText(R.string.lesson_step_review)
+                    binding.btnStepAction.isEnabled = true
+                    binding.btnStepAction.alpha = 1f
+                    binding.ivStepStatus.setImageResource(R.drawable.shield_bg)
+                    binding.cardContainer.setCardBackgroundColor(
+                        ContextCompat.getColor(context, R.color.step_card_background_completed)
+                    )
+                    binding.cardContainer.strokeColor =
+                        ContextCompat.getColor(context, R.color.step_card_stroke_completed)
+                }
+
+                item.isLocked -> {
+                    binding.tvStepStatus.visibility = View.GONE
+                    binding.btnStepAction.setText(R.string.lesson_step_locked)
+                    binding.btnStepAction.isEnabled = false
+                    binding.btnStepAction.alpha = 0.6f
+                    binding.ivStepStatus.setImageResource(R.drawable.shield_gray)
+                    binding.cardContainer.setCardBackgroundColor(
+                        ContextCompat.getColor(context, R.color.step_card_background)
+                    )
+                    binding.cardContainer.strokeColor =
+                        ContextCompat.getColor(context, R.color.step_card_stroke)
+                }
+
+                else -> {
+                    binding.tvStepStatus.visibility = View.GONE
+                    binding.btnStepAction.setText(R.string.lesson_step_open)
+                    binding.btnStepAction.isEnabled = true
+                    binding.btnStepAction.alpha = 1f
+                    binding.ivStepStatus.setImageResource(R.drawable.shield_gray)
+                    binding.cardContainer.setCardBackgroundColor(
+                        ContextCompat.getColor(context, R.color.step_card_background)
+                    )
+                    binding.cardContainer.strokeColor =
+                        ContextCompat.getColor(context, R.color.step_card_stroke)
+                }
             }
 
-            binding.btnStepAction.setOnClickListener { onStepSelected(item) }
+            binding.btnStepAction.setOnClickListener {
+                if (!item.isLocked) {
+                    onStepSelected(item)
+                }
+            }
+            binding.root.setOnClickListener {
+                if (!item.isLocked) {
+                    onStepSelected(item)
+                }
+            }
         }
     }
 

--- a/app/src/main/res/layout/fragment_lesson_step_detail.xml
+++ b/app/src/main/res/layout/fragment_lesson_step_detail.xml
@@ -55,9 +55,9 @@
                 android:layout_width="match_parent"
                 android:layout_height="240dp"
                 android:adjustViewBounds="true"
+                android:contentDescription="@null"
                 android:scaleType="centerCrop"
-                android:src="@drawable/steps_bg"
-                android:contentDescription="@null" />
+                android:src="@drawable/steps_bg" />
 
             <TextView
                 android:id="@+id/tvStepTitle"
@@ -109,6 +109,7 @@
                 android:text="@string/lesson_step_practice"
                 android:textColor="@color/white"
                 android:textSize="16sp" />
+
             <TextView
                 android:id="@+id/tvPractice"
                 android:layout_width="match_parent"
@@ -118,22 +119,24 @@
                 android:textColor="@color/white"
                 android:textSize="14sp"
                 tools:text="Read about the Pomodoro cycle. Write down the structure somewhere visible." />
+        </LinearLayout>
+
+        <androidx.appcompat.widget.AppCompatButton
+            android:id="@+id/btnCompleteQuest"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="center_horizontal"
             android:layout_marginTop="24dp"
+            android:layout_marginBottom="10dp"
+            android:background="@drawable/button_complete_quest"
+            android:letterSpacing="0.1"
             android:paddingHorizontal="28dp"
             android:paddingVertical="12dp"
             android:text="@string/lesson_step_complete"
             android:textAllCaps="false"
             android:textColor="@color/white"
             android:textSize="16sp" />
-</ScrollView>
-            android:paddingHorizontal="20dp"
-            android:letterSpacing="0.1"
-            android:layout_marginBottom="10dp"
-            android:background="@drawable/button_complete_quest"
-            android:layout_height="wrap_content"/>
-    </LinearLayout>
 
+    </LinearLayout>
 
 </ScrollView>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -44,11 +44,12 @@ Your quests await.</string>
     <string name="lesson_step_open">Open step</string>
     <string name="lesson_step_review">Review step</string>
     <string name="lesson_step_completed">Completed</string>
+    <string name="lesson_step_locked">Locked • Finish previous step</string>
     <string name="lesson_step_number_format">Step %1$d</string>
     <string name="lesson_step_theory">Theory</string>
     <string name="lesson_step_practice">Practice</string>
-    <string name="lesson_step_complete">Complete quest</string>
-    <string name="lesson_step_completed_button">Quest completed</string>
+    <string name="lesson_step_complete">Mark as Complete</string>
+    <string name="lesson_step_completed_button">Done</string>
     <string name="victory_next_lesson">Next Lesson</string>
     <string name="victory_replay_lesson">Replay Lesson</string>
     <string name="victory_title_template">Victory! %1$s completed</string>


### PR DESCRIPTION
## Summary
- lock lesson steps until the previous step is finished and show the state in the quest cards
- adjust the call-to-action enablement and copy so the quest flow matches the new wording
- rebuild the lesson step detail layout to ensure the completion button renders correctly

## Testing
- ./gradlew lint *(fails: SDK location not configured in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dedabad0bc832a938211ef31464cac