### PR TITLE
Show all lesson steps and fix lesson status visuals

### DIFF
--- a/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/lessons/LessonAdapter.kt
+++ b/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/lessons/LessonAdapter.kt
@@ -2,6 +2,7 @@ package sr.otaryp.tesatyla.presentation.ui.lessons
 
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import androidx.core.view.isVisible
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
@@ -34,7 +35,17 @@ class LessonAdapter(
             } else {
                 R.drawable.shield_gray
             }
-            binding.levelIm.setImageResource(iconRes)
+            binding.levelIm.apply {
+                setImageResource(iconRes)
+                contentDescription = binding.root.context.getString(
+                    if (item.isCompleted) {
+                        R.string.lesson_status_completed_icon_description
+                    } else {
+                        R.string.lesson_status_in_progress_icon_description
+                    }
+                )
+                isVisible = true
+            }
 
             val buttonTextRes = if (item.isCompleted) {
                 R.string.lesson_action_repeat

--- a/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/lessons/LessonDetailViewModel.kt
+++ b/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/lessons/LessonDetailViewModel.kt
@@ -20,20 +20,17 @@ class LessonDetailViewModel(
         .map { lessonWithSteps ->
             val lesson = lessonWithSteps.lesson
             val sortedSteps = lessonWithSteps.steps.sortedBy { it.number }
-            val firstIncompleteIndex = sortedSteps.indexOfFirst { !it.isCompleted }
-            val stepItems = sortedSteps
-                .mapIndexed { index, step ->
-                    val isLocked = !step.isCompleted && firstIncompleteIndex != -1 && index > firstIncompleteIndex
-                    LessonStepItem(
-                        id = step.id,
-                        lessonId = lesson.id,
-                        stepNumber = step.number,
-                        title = step.title,
-                        theoryPreview = step.theory.take(160),
-                        isCompleted = step.isCompleted,
-                        isLocked = isLocked
-                    )
-                }
+            val stepItems = sortedSteps.map { step ->
+                LessonStepItem(
+                    id = step.id,
+                    lessonId = lesson.id,
+                    stepNumber = step.number,
+                    title = step.title,
+                    theoryPreview = step.theory.take(160),
+                    isCompleted = step.isCompleted,
+                    isLocked = false
+                )
+            }
             val completedSteps = stepItems.count { it.isCompleted }
             LessonDetailUiState(
                 lessonId = lesson.id,

--- a/app/src/main/res/layout/item_lesson.xml
+++ b/app/src/main/res/layout/item_lesson.xml
@@ -12,13 +12,16 @@
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:gravity="center_vertical"
+        android:orientation="horizontal"
         android:padding="30dp">
 
         <LinearLayout
-            android:layout_width="wrap_content"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_gravity="center_vertical"
             android:layout_marginStart="15dp"
+            android:layout_weight="1"
             android:orientation="vertical">
 
             <TextView
@@ -43,11 +46,11 @@
         <ImageView
             android:id="@+id/levelIm"
             android:layout_width="wrap_content"
-            android:layout_height="110dp"
+            android:layout_height="wrap_content"
             android:layout_gravity="center_vertical|end"
             android:layout_marginEnd="10dp"
-            android:scaleType="fitEnd"
-            android:src="@drawable/shield_bg" />
+            android:adjustViewBounds="true"
+            android:src="@drawable/shield_gray" />
     </LinearLayout>
 
     <androidx.appcompat.widget.AppCompatButton

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -34,6 +34,8 @@ Your quests await.</string>
     <string name="lesson_action_repeat">Repeat Challenge</string>
     <string name="lesson_back">Back</string>
     <string name="lesson_detail_status_icon">Lesson progress icon</string>
+    <string name="lesson_status_in_progress_icon_description">Lesson in progress status</string>
+    <string name="lesson_status_completed_icon_description">Lesson completed status</string>
     <string name="lesson_detail_progress_in_progress">Quest in progress</string>
     <string name="lesson_detail_progress_completed">Quest completed</string>
     <string name="lesson_detail_progress_template">%1$d / %2$d steps completed</string>


### PR DESCRIPTION
## Summary
- show all lesson steps in the lesson detail screen so progress is not hidden after reopening
- default lesson cards to the gray shield and expose completed lessons with an accessible description
- adjust the lesson list item layout so the progress badge is visible alongside the lesson text

## Testing
- ./gradlew lint *(fails: SDK location not configured in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68df62de4ab4832ab27cca2577ee361a