### PR TITLE
Unlock lesson steps visibility and default shield icon

### DIFF
--- a/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/lessons/LessonDetailFragment.kt
+++ b/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/lessons/LessonDetailFragment.kt
@@ -132,7 +132,6 @@ class LessonDetailFragment : Fragment() {
     }
 
     private fun onStepSelected(step: LessonStepItem) {
-        if (step.isLocked) return
         val directions = LessonDetailFragmentDirections
             .actionLessonDetailFragmentToLessonStepDetailFragment(
                 lessonId = step.lessonId,

--- a/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/lessons/LessonStepDetailViewModel.kt
+++ b/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/lessons/LessonStepDetailViewModel.kt
@@ -29,9 +29,6 @@ class LessonStepDetailViewModel(
     ) { step, lessonWithSteps ->
         val lesson = lessonWithSteps.lesson
         val sortedSteps = lessonWithSteps.steps.sortedBy { it.number }
-        val currentIndex = sortedSteps.indexOfFirst { it.id == step.id }
-        val firstIncompleteIndex = sortedSteps.indexOfFirst { !it.isCompleted }
-        val isLocked = !step.isCompleted && firstIncompleteIndex != -1 && currentIndex > firstIncompleteIndex
         val remainingIncomplete = sortedSteps.count { !it.isCompleted }
         LessonStepDetailUiState(
             lessonId = lesson.id,
@@ -42,8 +39,8 @@ class LessonStepDetailViewModel(
             theory = step.theory,
             practice = step.practice,
             isCompleted = step.isCompleted,
-            isLocked = isLocked,
-            isLastIncompleteStep = !step.isCompleted && !isLocked && remainingIncomplete <= 1
+            isLocked = false,
+            isLastIncompleteStep = !step.isCompleted && remainingIncomplete <= 1
         )
     }.stateIn(
         scope = viewModelScope,

--- a/app/src/main/res/layout/item_lesson.xml
+++ b/app/src/main/res/layout/item_lesson.xml
@@ -47,7 +47,7 @@
             android:layout_gravity="center_vertical|end"
             android:layout_marginEnd="10dp"
             android:scaleType="fitEnd"
-            android:src="@drawable/shield_bg" />
+            android:src="@drawable/shield_gray" />
     </LinearLayout>
 
     <androidx.appcompat.widget.AppCompatButton


### PR DESCRIPTION
## Summary
- allow navigation to any lesson step without sequential locking
- default lesson list badge image to the gray shield placeholder

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df6cdb5afc832aa5a92f1bc1effd3d