### PR TITLE
Enhance lesson list navigation and quest CTA

### DIFF
--- a/app/src/main/java/sr/otaryp/tesatyla/data/lessons/LessonSeedData.kt
+++ b/app/src/main/java/sr/otaryp/tesatyla/data/lessons/LessonSeedData.kt
@@ -210,7 +210,7 @@ internal object LessonSeedData {
         LessonSeed(
             id = 6,
             title = "Lesson 6: The Focus Forge",
-            description = "Sharpen your concentration with practical drills and single-tasking mastery.",
+            description = "Sharpen your concentration with practical drills. Practice single-tasking, minimize context switching, and build mental endurance for deep work.",
             teaching = "This lesson strengthens the ability to maintain focus and resist multitasking.",
             steps = listOf(
                 LessonStepSeed(
@@ -248,7 +248,7 @@ internal object LessonSeedData {
         LessonSeed(
             id = 7,
             title = "Lesson 7: Energy Management",
-            description = "Align royal duties with your natural energy cycles and let rest refuel you.",
+            description = "Learn to align tasks with your natural energy cycles. Discover when you perform best, how breaks recharge you, and why rest is part of productivity.",
             teaching = "Learn to align tasks with natural energy cycles to optimize productivity and avoid burnout.",
             steps = listOf(
                 LessonStepSeed(
@@ -286,7 +286,7 @@ internal object LessonSeedData {
         LessonSeed(
             id = 8,
             title = "Lesson 8: Task Alchemy",
-            description = "Transform overwhelming quests into clear, actionable steps fit for victory.",
+            description = "Transform overwhelming projects into clear, actionable steps. Break down big goals into manageable tasks that you can actually finish.",
             teaching = "Learn to break large projects into smaller, manageable tasks, reducing overwhelm and increasing progress visibility.",
             steps = listOf(
                 LessonStepSeed(
@@ -324,7 +324,7 @@ internal object LessonSeedData {
         LessonSeed(
             id = 9,
             title = "Lesson 9: The Habit Loop",
-            description = "Understand how habits are forged and craft routines that lead to success.",
+            description = "Understand how habits are formed and how to rewire them. Create small daily routines that lead to long-term success.",
             teaching = "Learn to change or build habits using the cue → routine → reward model.",
             steps = listOf(
                 LessonStepSeed(
@@ -362,7 +362,7 @@ internal object LessonSeedData {
         LessonSeed(
             id = 10,
             title = "Lesson 10: The Reflection Chamber",
-            description = "Review the day’s wins, lessons, and areas to improve for steady progress.",
+            description = "End your day by reviewing wins, lessons, and areas to improve. Build a feedback loop that turns every day into progress.",
             teaching = "Reflection builds self-awareness, helps identify patterns, and improves decision-making and productivity.",
             steps = listOf(
                 LessonStepSeed(

--- a/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/lessons/LessonAdapter.kt
+++ b/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/lessons/LessonAdapter.kt
@@ -53,6 +53,7 @@ class LessonAdapter(
                 R.string.lesson_action_continue
             }
             binding.btnContinue.setText(buttonTextRes)
+            binding.btnContinue.contentDescription = binding.btnContinue.context.getString(buttonTextRes)
 
             binding.btnContinue.setOnClickListener { onLessonSelected(item) }
             binding.root.setOnClickListener { onLessonSelected(item) }

--- a/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/lessons/LessonDetailFragment.kt
+++ b/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/lessons/LessonDetailFragment.kt
@@ -67,20 +67,20 @@ class LessonDetailFragment : Fragment() {
     }
 
     private fun setupCallToAction() {
-//        binding.btnLessonCta.setOnClickListener {
-//            currentState?.let { state ->
-//                if (state.isCompleted) {
-//                    val directions = LessonDetailFragmentDirections
-//                        .actionLessonDetailFragmentToVictoryHallFragment(state.lessonId)
-//                    findNavController().navigate(directions)
-//                } else {
-//                    val nextStep = state.steps.firstOrNull { !it.isCompleted }
-//                    if (nextStep != null) {
-//                        onStepSelected(nextStep)
-//                    }
-//                }
-//            }
-//        }
+        binding.btnLessonCta.setOnClickListener {
+            currentState?.let { state ->
+                if (state.isCompleted) {
+                    val directions = LessonDetailFragmentDirections
+                        .actionLessonDetailFragmentToVictoryHallFragment(state.lessonId)
+                    findNavController().navigate(directions)
+                } else {
+                    val nextStep = state.steps.firstOrNull { !it.isLocked && !it.isCompleted }
+                    if (nextStep != null) {
+                        onStepSelected(nextStep)
+                    }
+                }
+            }
+        }
     }
 
     private fun observeUiState() {
@@ -91,34 +91,18 @@ class LessonDetailFragment : Fragment() {
                     binding.tvLessonTitle.text = state.title
                     binding.tvLessonDescription.text = state.description
                     binding.tvLessonTeaching.text = state.teaching
-//                    binding.ivLessonStatus.setImageResource(
-//                        if (state.isCompleted) R.drawable.shield_bg else R.drawable.shield_gray
-//                    )
-//                    binding.tvLessonStatus.setText(
-//                        if (state.isCompleted) {
-//                            R.string.lesson_detail_progress_completed
-//                        } else {
-//                            R.string.lesson_detail_progress_in_progress
-//                        }
-//                    )
-//                    binding.tvLessonProgress.text = getString(
-//                        R.string.lesson_detail_progress_template,
-//                        state.completedSteps,
-//                        state.totalSteps
-//                    )
                     val hasSteps = state.totalSteps > 0
                     val hasAccessibleStep = state.steps.any { !it.isLocked && !it.isCompleted }
-//                    binding.tvLessonProgress.isVisible = hasSteps
-//                    binding.progressContainer.isVisible = hasSteps
-//                    binding.btnLessonCta.setText(
-//                        if (state.isCompleted) {
-//                            R.string.lesson_detail_cta_victory
-//                        } else {
-//                            R.string.lesson_detail_cta_complete
-//                        }
-//                    )
-//                    binding.btnLessonCta.isEnabled = state.isCompleted || hasAccessibleStep
-//                    binding.btnLessonCta.alpha = if (state.isCompleted || hasAccessibleStep) 1f else 0.6f
+                    binding.btnLessonCta.isVisible = hasSteps
+                    val ctaTextRes = if (state.isCompleted) {
+                        R.string.lesson_detail_cta_victory
+                    } else {
+                        R.string.lesson_detail_cta_complete
+                    }
+                    binding.btnLessonCta.setText(ctaTextRes)
+                    binding.btnLessonCta.contentDescription = getString(ctaTextRes)
+                    binding.btnLessonCta.isEnabled = state.isCompleted || hasAccessibleStep
+                    binding.btnLessonCta.alpha = if (state.isCompleted || hasAccessibleStep) 1f else 0.6f
                     stepsAdapter.submitList(state.steps)
 
                     LessonProgressPreferences.setCurrentLesson(

--- a/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/lessons/LessonListFragment.kt
+++ b/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/lessons/LessonListFragment.kt
@@ -11,7 +11,6 @@ import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.LinearLayoutManager
-import sr.otaryp.tesatyla.R
 import sr.otaryp.tesatyla.data.preferences.LessonProgressPreferences
 import sr.otaryp.tesatyla.databinding.FragmentLessonListBinding
 import kotlin.LazyThreadSafetyMode
@@ -53,7 +52,8 @@ class LessonListFragment : Fragment() {
 
     private fun setupToolbar() {
         binding.btnBack.setOnClickListener {
-            findNavController().navigateUp()
+            val directions = LessonListFragmentDirections.actionNavLessonsToNavHome()
+            findNavController().navigate(directions)
         }
     }
 
@@ -66,24 +66,23 @@ class LessonListFragment : Fragment() {
     }
 
     private fun observeLessons() {
-
-viewLifecycleOwner.lifecycleScope.launch {
-    viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
-        viewModel.lessons.collect { lessons ->
-            lessonAdapter.submitList(lessons)
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.lessons.collect { lessons ->
+                    lessonAdapter.submitList(lessons)
+                }
+            }
         }
     }
-}
-}
 
-private fun onLessonSelected(lesson: LessonListItem) {
-    LessonProgressPreferences.setCurrentLesson(
-        requireContext(),
-        lesson.id,
-        lesson.title
-    )
-    val directions = LessonListFragmentDirections
-        .actionNavLessonsToLessonDetailFragment(lesson.id)
-    findNavController().navigate(directions)
-}
+    private fun onLessonSelected(lesson: LessonListItem) {
+        LessonProgressPreferences.setCurrentLesson(
+            requireContext(),
+            lesson.id,
+            lesson.title
+        )
+        val directions = LessonListFragmentDirections
+            .actionNavLessonsToLessonDetailFragment(lesson.id)
+        findNavController().navigate(directions)
+    }
 }

--- a/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/lessons/LessonStepsAdapter.kt
+++ b/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/lessons/LessonStepsAdapter.kt
@@ -1,9 +1,7 @@
 package sr.otaryp.tesatyla.presentation.ui.lessons
 
 import android.view.LayoutInflater
-import android.view.View
 import android.view.ViewGroup
-import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
@@ -36,8 +34,14 @@ class LessonStepsAdapter(
             binding.tvStepTitle.text = item.title
             binding.tvStepPreview.text = item.theoryPreview
 
-            // Текст кнопки по статусу шага (можешь заменить на строки-ресурсы при желании)
-            binding.btnOpenStep.text = if (item.isCompleted) "Review" else "Continue"
+            val context = binding.root.context
+            val buttonTextRes = if (item.isCompleted) {
+                R.string.lesson_step_review
+            } else {
+                R.string.lesson_step_open
+            }
+            binding.btnOpenStep.setText(buttonTextRes)
+            binding.btnOpenStep.contentDescription = context.getString(buttonTextRes)
 
             binding.btnOpenStep.setOnClickListener { onStepSelected(item) }
             binding.root.setOnClickListener { onStepSelected(item) }

--- a/app/src/main/res/layout/fragment_lesson_detail.xml
+++ b/app/src/main/res/layout/fragment_lesson_detail.xml
@@ -116,8 +116,25 @@
             android:layout_height="wrap_content"
             android:layout_marginHorizontal="20dp"
             android:layout_marginTop="12dp"
-            android:layout_marginBottom="20dp"
             android:nestedScrollingEnabled="false"
             tools:listitem="@layout/lessson_step_item" />
+
+        <androidx.appcompat.widget.AppCompatButton
+            android:id="@+id/btnLessonCta"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_horizontal"
+            android:layout_marginTop="16dp"
+            android:layout_marginBottom="32dp"
+            android:background="@drawable/btn_enter_kingdom1"
+            android:minWidth="220dp"
+            android:minHeight="0dp"
+            android:paddingHorizontal="36dp"
+            android:paddingVertical="16dp"
+            android:text="@string/lesson_detail_cta_complete"
+            android:textAllCaps="false"
+            android:textColor="#FFE08A"
+            android:textSize="18sp"
+            android:textStyle="bold" />
     </LinearLayout>
 </ScrollView>

--- a/app/src/main/res/layout/item_lesson.xml
+++ b/app/src/main/res/layout/item_lesson.xml
@@ -35,6 +35,8 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:fontFamily="@font/inter_18pt_medium"
+                android:maxLines="3"
+                android:ellipsize="end"
                 android:text="Pick up your sword\nwhere you left off."
                 android:textColor="@color/white"
                 android:textSize="13sp" />
@@ -60,7 +62,7 @@
         android:minHeight="0dp"
         android:paddingHorizontal="30dp"
         android:paddingVertical="14dp"
-        android:text="Continue"
+        android:text="@string/lesson_action_continue"
         android:textAllCaps="false"
         android:textColor="#FFE08A"
         android:textSize="18sp"

--- a/app/src/main/res/layout/lessson_step_item.xml
+++ b/app/src/main/res/layout/lessson_step_item.xml
@@ -28,6 +28,8 @@
             android:layout_height="wrap_content"
             android:layout_gravity="center"
             android:gravity="center"
+            android:maxLines="3"
+            android:ellipsize="end"
             android:text="Theory: The Pomodoro method divides work into cycles of 25 minutes ..." />
 
 
@@ -43,7 +45,7 @@
         android:minHeight="0dp"
         android:paddingHorizontal="30dp"
         android:paddingVertical="14dp"
-        android:text="Continue"
+        android:text="@string/lesson_step_open"
         android:textAllCaps="false"
         android:textColor="#FFE08A"
         android:textSize="18sp"

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -56,6 +56,12 @@
         android:label="Lessons"
         tools:layout="@layout/fragment_lesson_list">
         <action
+            android:id="@+id/action_nav_lessons_to_nav_home"
+            app:destination="@id/nav_home"
+            app:launchSingleTop="true"
+            app:popUpTo="@id/nav_lessons"
+            app:popUpToInclusive="true" />
+        <action
             android:id="@+id/action_nav_lessons_to_lessonDetailFragment"
             app:destination="@id/lessonDetailFragment" />
     </fragment>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -74,13 +74,13 @@ Your quests await.</string>
     <string name="lesson_title_procrastination_dragon">The Procrastination Dragon</string>
     <string name="lesson_description_procrastination_dragon">Face the beast of delay and strike with proven action techniques.</string>
     <string name="lesson_title_focus_forge">The Focus Forge</string>
-    <string name="lesson_description_focus_forge">Sharpen your concentration with practical drills and single-tasking mastery.</string>
+    <string name="lesson_description_focus_forge">Sharpen your concentration with practical drills. Practice single-tasking, minimize context switching, and build mental endurance for deep work.</string>
     <string name="lesson_title_energy_management">Energy Management</string>
-    <string name="lesson_description_energy_management">Align royal duties with your natural energy cycles and let rest refuel you.</string>
+    <string name="lesson_description_energy_management">Learn to align tasks with your natural energy cycles. Discover when you perform best, how breaks recharge you, and why rest is part of productivity.</string>
     <string name="lesson_title_task_alchemy">Task Alchemy</string>
-    <string name="lesson_description_task_alchemy">Transform overwhelming quests into clear, actionable steps fit for victory.</string>
+    <string name="lesson_description_task_alchemy">Transform overwhelming projects into clear, actionable steps. Break down big goals into manageable tasks that you can actually finish.</string>
     <string name="lesson_title_habit_loop">The Habit Loop</string>
-    <string name="lesson_description_habit_loop">Understand how habits are forged and craft routines that lead to success.</string>
+    <string name="lesson_description_habit_loop">Understand how habits are formed and how to rewire them. Create small daily routines that lead to long-term success.</string>
     <string name="lesson_title_reflection_chamber">The Reflection Chamber</string>
-    <string name="lesson_description_reflection_chamber">Review the day’s wins, lessons, and areas to improve for steady progress.</string>
+    <string name="lesson_description_reflection_chamber">End your day by reviewing wins, lessons, and areas to improve. Build a feedback loop that turns every day into progress.</string>
 </resources>


### PR DESCRIPTION
## Summary
- add a dedicated navigation action so the lessons back button returns to the home screen
- restore the lesson detail call-to-action button so it opens the next unfinished step or celebrates in the Victory Hall when completed
- refresh lesson resources with updated copy, accessibility tweaks, and limited-length previews for list and step items

## Testing
- `./gradlew lintDebug` *(fails: Android SDK is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68df8173a3c4832a9405ace4e26cbcff