### PR TITLE
Remove lesson step locked state

### DIFF
--- a/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/lessons/LessonDetailFragment.kt
+++ b/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/lessons/LessonDetailFragment.kt
@@ -74,7 +74,7 @@ class LessonDetailFragment : Fragment() {
                         .actionLessonDetailFragmentToVictoryHallFragment(state.lessonId)
                     findNavController().navigate(directions)
                 } else {
-                    val nextStep = state.steps.firstOrNull { !it.isLocked && !it.isCompleted }
+                    val nextStep = state.steps.firstOrNull { !it.isCompleted }
                     if (nextStep != null) {
                         onStepSelected(nextStep)
                     }
@@ -92,7 +92,7 @@ class LessonDetailFragment : Fragment() {
                     binding.tvLessonDescription.text = state.description
                     binding.tvLessonTeaching.text = state.teaching
                     val hasSteps = state.totalSteps > 0
-                    val hasAccessibleStep = state.steps.any { !it.isLocked && !it.isCompleted }
+                    val hasIncompleteStep = state.steps.any { !it.isCompleted }
                     binding.btnLessonCta.isVisible = hasSteps
                     val ctaTextRes = if (state.isCompleted) {
                         R.string.lesson_detail_cta_victory
@@ -101,8 +101,8 @@ class LessonDetailFragment : Fragment() {
                     }
                     binding.btnLessonCta.setText(ctaTextRes)
                     binding.btnLessonCta.contentDescription = getString(ctaTextRes)
-                    binding.btnLessonCta.isEnabled = state.isCompleted || hasAccessibleStep
-                    binding.btnLessonCta.alpha = if (state.isCompleted || hasAccessibleStep) 1f else 0.6f
+                    binding.btnLessonCta.isEnabled = state.isCompleted || hasIncompleteStep
+                    binding.btnLessonCta.alpha = if (state.isCompleted || hasIncompleteStep) 1f else 0.6f
                     stepsAdapter.submitList(state.steps)
 
                     LessonProgressPreferences.setCurrentLesson(

--- a/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/lessons/LessonDetailViewModel.kt
+++ b/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/lessons/LessonDetailViewModel.kt
@@ -27,8 +27,7 @@ class LessonDetailViewModel(
                     stepNumber = step.number,
                     title = step.title,
                     theoryPreview = step.theory.take(160),
-                    isCompleted = step.isCompleted,
-                    isLocked = false
+                    isCompleted = step.isCompleted
                 )
             }
             val completedSteps = stepItems.count { it.isCompleted }
@@ -83,6 +82,5 @@ data class LessonStepItem(
     val stepNumber: Int,
     val title: String,
     val theoryPreview: String,
-    val isCompleted: Boolean,
-    val isLocked: Boolean
+    val isCompleted: Boolean
 )

--- a/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/lessons/LessonStepDetailFragment.kt
+++ b/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/lessons/LessonStepDetailFragment.kt
@@ -82,26 +82,15 @@ class LessonStepDetailFragment : Fragment() {
                     binding.tvTheory.text = state.theory
                     binding.tvPractice.text = state.practice
 
-                    when {
-                        state.isCompleted -> {
-                            binding.tvStepStatus.isVisible = true
-                            binding.tvStepStatus.setText(R.string.lesson_step_completed_message)
-                            binding.btnCompleteQuest.isEnabled = false
-                            binding.btnCompleteQuest.text = getString(R.string.lesson_step_completed_button)
-                        }
-
-                        state.isLocked -> {
-                            binding.tvStepStatus.isVisible = true
-                            binding.tvStepStatus.setText(R.string.lesson_step_locked_detail)
-                            binding.btnCompleteQuest.isEnabled = false
-                            binding.btnCompleteQuest.text = getString(R.string.lesson_step_locked)
-                        }
-
-                        else -> {
-                            binding.tvStepStatus.isVisible = false
-                            binding.btnCompleteQuest.isEnabled = true
-                            binding.btnCompleteQuest.text = getString(R.string.lesson_step_complete)
-                        }
+                    if (state.isCompleted) {
+                        binding.tvStepStatus.isVisible = true
+                        binding.tvStepStatus.setText(R.string.lesson_step_completed_message)
+                        binding.btnCompleteQuest.isEnabled = false
+                        binding.btnCompleteQuest.text = getString(R.string.lesson_step_completed_button)
+                    } else {
+                        binding.tvStepStatus.isVisible = false
+                        binding.btnCompleteQuest.isEnabled = true
+                        binding.btnCompleteQuest.text = getString(R.string.lesson_step_complete)
                     }
                     binding.btnCompleteQuest.alpha =
                         if (binding.btnCompleteQuest.isEnabled) 1f else 0.6f

--- a/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/lessons/LessonStepDetailViewModel.kt
+++ b/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/lessons/LessonStepDetailViewModel.kt
@@ -39,7 +39,6 @@ class LessonStepDetailViewModel(
             theory = step.theory,
             practice = step.practice,
             isCompleted = step.isCompleted,
-            isLocked = false,
             isLastIncompleteStep = !step.isCompleted && remainingIncomplete <= 1
         )
     }.stateIn(
@@ -50,7 +49,7 @@ class LessonStepDetailViewModel(
 
     fun onCompleteStep() {
         val currentState = uiState.value
-        if (currentState.isCompleted || currentState.isLocked) {
+        if (currentState.isCompleted) {
             return
         }
         viewModelScope.launch {
@@ -105,7 +104,6 @@ data class LessonStepDetailUiState(
     val theory: String = "",
     val practice: String = "",
     val isCompleted: Boolean = false,
-    val isLocked: Boolean = false,
     val isLastIncompleteStep: Boolean = false
 )
 


### PR DESCRIPTION
## Summary
- remove the locked flag from lesson detail and step view models
- update lesson detail and step fragments to rely solely on completion status

## Testing
- not run (Android SDK not available in environment)


------
https://chatgpt.com/codex/tasks/task_e_68df8b764118832aaa5e3dcd95e8845d