### PR TITLE
Fix lesson steps list rendering inside lesson detail

### DIFF
--- a/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/common/NonScrollableRecyclerView.kt
+++ b/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/common/NonScrollableRecyclerView.kt
@@ -1,0 +1,28 @@
+package sr.otaryp.tesatyla.presentation.ui.common
+
+import android.content.Context
+import android.util.AttributeSet
+import androidx.recyclerview.widget.RecyclerView
+
+/**
+ * A RecyclerView implementation that expands to show all of its content and
+ * delegates vertical scrolling to the parent container. This is useful when
+ * the RecyclerView is placed inside another scrollable view (e.g. ScrollView)
+ * and we still want to render the full list of items.
+ */
+class NonScrollableRecyclerView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0
+) : RecyclerView(context, attrs, defStyleAttr) {
+
+    override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
+        val expandedHeightSpec = MeasureSpec.makeMeasureSpec(
+            Int.MAX_VALUE shr 2,
+            MeasureSpec.AT_MOST
+        )
+        super.onMeasure(widthMeasureSpec, expandedHeightSpec)
+    }
+
+    override fun canScrollVertically(): Boolean = false
+}

--- a/app/src/main/res/layout/fragment_lesson_detail.xml
+++ b/app/src/main/res/layout/fragment_lesson_detail.xml
@@ -110,7 +110,7 @@
             android:textColor="@color/white"
             android:textSize="18sp" />
 
-        <androidx.recyclerview.widget.RecyclerView
+        <sr.otaryp.tesatyla.presentation.ui.common.NonScrollableRecyclerView
             android:id="@+id/rvSteps"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"


### PR DESCRIPTION
## Summary
- add a non-scrollable RecyclerView implementation that expands to show all lesson steps
- update the lesson detail layout to use the custom view so every step remains visible inside the scroll container

## Testing
- ./gradlew lintDebug *(fails: Android SDK is not configured in the current environment)*

------
https://chatgpt.com/codex/tasks/task_e_68df92622a14832abf5c392675b95ee8