### PR TITLE
Add Pomodoro timer logic to FocusFragment

### DIFF
--- a/app/src/main/java/sr/otaryp/tesatyla/data/preferences/FocusPreferences.kt
+++ b/app/src/main/java/sr/otaryp/tesatyla/data/preferences/FocusPreferences.kt
@@ -1,0 +1,61 @@
+package sr.otaryp.tesatyla.data.preferences
+
+import android.content.Context
+import androidx.core.content.edit
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+object FocusPreferences {
+
+    private const val PREFS_NAME = "focus_prefs"
+    private const val KEY_DATE = "focus_date"
+    private const val KEY_COUNT = "focus_count"
+
+    private val dateFormat = SimpleDateFormat("yyyyMMdd", Locale.getDefault())
+
+    private fun todayKey(): String = dateFormat.format(Date())
+
+    private fun sharedPreferences(context: Context) =
+        context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+
+    fun getTodayCount(context: Context): Int {
+        val preferences = sharedPreferences(context)
+        val savedDate = preferences.getString(KEY_DATE, null)
+        return if (savedDate == todayKey()) {
+            preferences.getInt(KEY_COUNT, 0)
+        } else {
+            0
+        }
+    }
+
+    fun incrementTodayCount(context: Context): Int {
+        val preferences = sharedPreferences(context)
+        val today = todayKey()
+        val newCount = if (preferences.getString(KEY_DATE, null) == today) {
+            preferences.getInt(KEY_COUNT, 0) + 1
+        } else {
+            1
+        }
+        preferences.edit {
+            putString(KEY_DATE, today)
+            putInt(KEY_COUNT, newCount)
+        }
+        return newCount
+    }
+
+    fun ensureTodayCount(context: Context): Int {
+        val preferences = sharedPreferences(context)
+        val today = todayKey()
+        val savedDate = preferences.getString(KEY_DATE, null)
+        return if (savedDate == today) {
+            preferences.getInt(KEY_COUNT, 0)
+        } else {
+            preferences.edit {
+                putString(KEY_DATE, today)
+                putInt(KEY_COUNT, 0)
+            }
+            0
+        }
+    }
+}

--- a/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/progress/ProgressFragment.kt
+++ b/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/progress/ProgressFragment.kt
@@ -1,21 +1,55 @@
 package sr.otaryp.tesatyla.presentation.ui.progress
 
 import android.os.Bundle
-import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.fragment.app.Fragment
 import sr.otaryp.tesatyla.R
+import sr.otaryp.tesatyla.data.preferences.FocusPreferences
+import sr.otaryp.tesatyla.databinding.FragmentProgressBinding
 
 class ProgressFragment : Fragment() {
 
+    private var _binding: FragmentProgressBinding? = null
+    private val binding get() = _binding!!
+
     override fun onCreateView(
-        inflater: LayoutInflater, container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View? {
-        // Inflate the layout for this fragment
-        return inflater.inflate(R.layout.fragment_progress, container, false)
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View {
+        _binding = FragmentProgressBinding.inflate(inflater, container, false)
+        return binding.root
     }
 
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        binding.progressBar.max = PROGRESS_MAX
+        updateProgress()
+    }
 
+    override fun onResume() {
+        super.onResume()
+        updateProgress()
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+
+    private fun updateProgress() {
+        val completedToday = FocusPreferences.ensureTodayCount(requireContext())
+        val percent = ((completedToday.toFloat() / DAILY_GOAL) * PROGRESS_MAX).toInt().coerceIn(0, PROGRESS_MAX)
+
+        binding.progressPercentage.text = getString(R.string.progress_percentage_format, percent)
+        binding.pomodoroCycles.text = getString(R.string.progress_cycles_format, completedToday)
+        binding.progressBar.progress = percent
+    }
+
+    companion object {
+        private const val DAILY_GOAL = 12f
+        private const val PROGRESS_MAX = 100
+    }
 }

--- a/app/src/main/res/layout/fragment_focus.xml
+++ b/app/src/main/res/layout/fragment_focus.xml
@@ -60,13 +60,54 @@
                 android:layout_marginTop="10dp"
                 android:src="@drawable/timer_bg" />
 
-            <TextView
+            <LinearLayout
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center"
-                android:fontFamily="@font/inter_18pt_extrabold"
-                android:text="25:00"
-                android:textSize="40sp" />
+                android:gravity="center"
+                android:orientation="vertical">
+
+                <TextView
+                    android:id="@+id/session_status"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:fontFamily="@font/inter_18pt_bold"
+                    android:text="Focus Session"
+                    android:textColor="@color/white"
+                    android:textSize="16sp" />
+
+                <TextView
+                    android:id="@+id/timer"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:fontFamily="@font/inter_18pt_extrabold"
+                    android:text="25:00"
+                    android:textSize="40sp" />
+
+                <TextView
+                    android:id="@+id/session_info"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="4dp"
+                    android:fontFamily="@font/inter_18pt_bold"
+                    android:text="Focus 25 min · Break 5 min"
+                    android:textColor="@color/white"
+                    android:textSize="12sp" />
+            </LinearLayout>
+
+            <ProgressBar
+                android:id="@+id/progress_bar"
+                style="?android:attr/progressBarStyleHorizontal"
+                android:layout_width="match_parent"
+                android:layout_height="10dp"
+                android:layout_gravity="bottom"
+                android:layout_marginStart="40dp"
+                android:layout_marginEnd="40dp"
+                android:layout_marginBottom="36dp"
+                android:indeterminate="false"
+                android:max="100"
+                android:progress="0"
+                android:progressDrawable="@drawable/progress_layer" />
         </FrameLayout>
 
         <FrameLayout
@@ -92,19 +133,25 @@
                     android:orientation="horizontal">
 
                     <ImageView
+                        android:id="@+id/btnStart"
                         android:layout_width="70dp"
                         android:layout_height="70dp"
+                        android:contentDescription="@string/content_description_start"
                         android:src="@drawable/start_button_im" />
 
                     <ImageView
+                        android:id="@+id/btnPause"
                         android:layout_width="70dp"
                         android:layout_height="70dp"
                         android:layout_marginHorizontal="20dp"
+                        android:contentDescription="@string/content_description_pause"
                         android:src="@drawable/pause_button_im" />
 
                     <ImageView
+                        android:id="@+id/btnReplay"
                         android:layout_width="70dp"
                         android:layout_height="70dp"
+                        android:contentDescription="@string/content_description_reset"
                         android:src="@drawable/replay_button_im" />
                 </LinearLayout>
 
@@ -124,11 +171,12 @@
                         android:textSize="14sp"/>
 
                     <TextView
+                        android:id="@+id/completed_pomodoros"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_gravity="center"
-                        android:text="5"
                         android:fontFamily="@font/inter_18pt_extrabold"
+                        android:text="0"
                         android:textColor="@color/white"
                         android:textSize="25sp"/>
                 </LinearLayout>

--- a/app/src/main/res/layout/fragment_progress.xml
+++ b/app/src/main/res/layout/fragment_progress.xml
@@ -87,20 +87,22 @@
                 android:src="@drawable/progress_bg2" />
 
             <TextView
+                android:id="@+id/progress_percentage"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center"
                 android:fontFamily="@font/inter_18pt_extrabold"
-                android:text="75%"
+                android:text="0%"
                 android:textSize="40sp" />
         </FrameLayout>
 
         <TextView
+            android:id="@+id/pomodoro_cycles"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="center"
             android:fontFamily="@font/inter_18pt_bold"
-            android:text="Pomodoro Cycles Completed: 4"
+            android:text="Pomodoro Cycles Completed: 0"
             android:textSize="18sp" />
 
         <TextView

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -83,4 +83,15 @@ Your quests await.</string>
     <string name="lesson_description_habit_loop">Understand how habits are formed and how to rewire them. Create small daily routines that lead to long-term success.</string>
     <string name="lesson_title_reflection_chamber">The Reflection Chamber</string>
     <string name="lesson_description_reflection_chamber">End your day by reviewing wins, lessons, and areas to improve. Build a feedback loop that turns every day into progress.</string>
+    <string name="content_description_start">Start pomodoro session</string>
+    <string name="content_description_pause">Pause pomodoro session</string>
+    <string name="content_description_reset">Reset pomodoro session</string>
+    <string name="focus_session_label">Focus Session</string>
+    <string name="break_session_label">Break</string>
+    <string name="focus_session_info">Focus %1$d min · Break %2$d min</string>
+    <string name="focus_victory_message">Victory! Task Completed</string>
+    <string name="focus_break_message">Break time! Enjoy %1$d minutes of rest.</string>
+    <string name="focus_break_complete_message">Break over! Ready for your next focus quest.</string>
+    <string name="progress_percentage_format">%1$d%%</string>
+    <string name="progress_cycles_format">Pomodoro Cycles Completed: %1$d</string>
 </resources>


### PR DESCRIPTION
## Summary
- implement full Pomodoro countdown workflow in FocusFragment with start, pause, reset, and automatic break handling
- persist and surface daily Pomodoro completions through a shared FocusPreferences helper that also refreshes ProgressFragment stats
- add required view identifiers and session information to the focus and progress layouts along with accessibility strings

## Testing
- ./gradlew test *(fails: Android SDK is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dfa438720c832a819a914ce0f1da81