### PR TITLE
feat: build progress overview screen

### DIFF
--- a/app/src/main/java/sr/otaryp/tesatyla/data/lessons/SkillCatalog.kt
+++ b/app/src/main/java/sr/otaryp/tesatyla/data/lessons/SkillCatalog.kt
@@ -1,0 +1,40 @@
+package sr.otaryp.tesatyla.data.lessons
+
+/**
+ * Provides groupings of lessons into broader skill themes that can be
+ * displayed on the progress screen. Each skill contains the ids of the
+ * lessons that reinforce it so that progress can be aggregated per skill
+ * and filtered in the lesson list screen.
+ */
+object SkillCatalog {
+
+    data class Skill(
+        val id: String,
+        val title: String,
+        val lessonIds: List<Int>,
+    )
+
+    val skills: List<Skill> = listOf(
+        Skill(
+            id = "focus",
+            title = "Focus & Distraction Shield",
+            lessonIds = listOf(1, 3),
+        ),
+        Skill(
+            id = "planning",
+            title = "Planning & Time Mastery",
+            lessonIds = listOf(2, 4),
+        ),
+        Skill(
+            id = "momentum",
+            title = "Momentum & Motivation",
+            lessonIds = listOf(5),
+        ),
+    )
+
+    fun findSkill(skillId: String?): Skill? {
+        if (skillId.isNullOrBlank()) return null
+        return skills.firstOrNull { it.id == skillId }
+    }
+}
+

--- a/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/progress/ProgressViewModel.kt
+++ b/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/progress/ProgressViewModel.kt
@@ -1,0 +1,117 @@
+package sr.otaryp.tesatyla.presentation.ui.progress
+
+import android.content.Context
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import kotlin.math.roundToInt
+import sr.otaryp.tesatyla.data.lessons.LessonRepository
+import sr.otaryp.tesatyla.data.lessons.SkillCatalog
+import sr.otaryp.tesatyla.data.preferences.FocusPreferences
+
+class ProgressViewModel(
+    private val repository: LessonRepository,
+) : ViewModel() {
+
+    private val pomodoroCount = MutableStateFlow(0)
+
+    private val lessonProgress = repository.observeLessons()
+        .map { lessons ->
+            val totalLessons = lessons.size
+            val completedLessons = lessons.count { it.lesson.isCompleted }
+
+            val skills = SkillCatalog.skills.mapNotNull { skill ->
+                val skillLessons = lessons.filter { skill.lessonIds.contains(it.lesson.id) }
+                if (skillLessons.isEmpty()) return@mapNotNull null
+
+                val total = skillLessons.size
+                val completed = skillLessons.count { it.lesson.isCompleted }
+                SkillProgressItem(
+                    id = skill.id,
+                    title = skill.title,
+                    completedLessons = completed,
+                    totalLessons = total,
+                    completionPercent = if (total == 0) 0 else ((completed.toFloat() / total) * 100).roundToInt(),
+                )
+            }
+
+            LessonProgressSnapshot(
+                completedLessons = completedLessons,
+                totalLessons = totalLessons,
+                overallPercent = if (totalLessons == 0) 0 else ((completedLessons.toFloat() / totalLessons) * 100).roundToInt(),
+                skills = skills,
+            )
+        }
+
+    val uiState: StateFlow<ProgressUiState> = combine(lessonProgress, pomodoroCount) { progress, pomodoros ->
+        ProgressUiState(
+            overallPercent = progress.overallPercent,
+            completedLessons = progress.completedLessons,
+            totalLessons = progress.totalLessons,
+            skills = progress.skills,
+            pomodoroCycles = pomodoros,
+        )
+    }.stateIn(
+        viewModelScope,
+        SharingStarted.WhileSubscribed(5_000),
+        ProgressUiState(),
+    )
+
+    fun refreshPomodoroCount(context: Context) {
+        viewModelScope.launch {
+            val count = withContext(Dispatchers.IO) {
+                FocusPreferences.ensureTodayCount(context)
+            }
+            pomodoroCount.update { count }
+        }
+    }
+
+    private data class LessonProgressSnapshot(
+        val completedLessons: Int,
+        val totalLessons: Int,
+        val overallPercent: Int,
+        val skills: List<SkillProgressItem>,
+    )
+
+    companion object {
+        const val DAILY_POMODORO_GOAL = 12
+
+        fun provideFactory(context: Context): ViewModelProvider.Factory {
+            val appContext = context.applicationContext
+            return object : ViewModelProvider.Factory {
+                @Suppress("UNCHECKED_CAST")
+                override fun <T : ViewModel> create(modelClass: Class<T>): T {
+                    val repository = LessonRepository.getInstance(appContext)
+                    return ProgressViewModel(repository) as T
+                }
+            }
+        }
+    }
+}
+
+data class ProgressUiState(
+    val overallPercent: Int = 0,
+    val completedLessons: Int = 0,
+    val totalLessons: Int = 0,
+    val skills: List<SkillProgressItem> = emptyList(),
+    val pomodoroCycles: Int = 0,
+)
+
+data class SkillProgressItem(
+    val id: String,
+    val title: String,
+    val completedLessons: Int,
+    val totalLessons: Int,
+    val completionPercent: Int,
+)
+

--- a/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/progress/SkillProgressAdapter.kt
+++ b/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/progress/SkillProgressAdapter.kt
@@ -1,0 +1,57 @@
+package sr.otaryp.tesatyla.presentation.ui.progress
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import sr.otaryp.tesatyla.R
+import sr.otaryp.tesatyla.databinding.ItemSkillProgressBinding
+
+class SkillProgressAdapter(
+    private val onSkillSelected: (SkillProgressItem) -> Unit,
+) : ListAdapter<SkillProgressItem, SkillProgressAdapter.SkillProgressViewHolder>(DiffCallback) {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): SkillProgressViewHolder {
+        val inflater = LayoutInflater.from(parent.context)
+        val binding = ItemSkillProgressBinding.inflate(inflater, parent, false)
+        return SkillProgressViewHolder(binding, onSkillSelected)
+    }
+
+    override fun onBindViewHolder(holder: SkillProgressViewHolder, position: Int) {
+        holder.bind(getItem(position))
+    }
+
+    class SkillProgressViewHolder(
+        private val binding: ItemSkillProgressBinding,
+        private val onSkillSelected: (SkillProgressItem) -> Unit,
+    ) : RecyclerView.ViewHolder(binding.root) {
+
+        fun bind(item: SkillProgressItem) {
+            val context = binding.root.context
+            binding.textSkillTitle.text = item.title
+            binding.textSkillLessons.text = context.getString(
+                R.string.progress_lessons_completed,
+                item.completedLessons,
+                item.totalLessons,
+            )
+            binding.textSkillPercent.text = context.getString(
+                R.string.progress_percentage_format,
+                item.completionPercent,
+            )
+            binding.skillProgressBar.max = 100
+            binding.skillProgressBar.progress = item.completionPercent
+
+            binding.root.setOnClickListener { onSkillSelected(item) }
+        }
+    }
+
+    private object DiffCallback : DiffUtil.ItemCallback<SkillProgressItem>() {
+        override fun areItemsTheSame(oldItem: SkillProgressItem, newItem: SkillProgressItem): Boolean =
+            oldItem.id == newItem.id
+
+        override fun areContentsTheSame(oldItem: SkillProgressItem, newItem: SkillProgressItem): Boolean =
+            oldItem == newItem
+    }
+}
+

--- a/app/src/main/res/layout/fragment_progress.xml
+++ b/app/src/main/res/layout/fragment_progress.xml
@@ -4,197 +4,172 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@drawable/progress_bg"
+    android:background="@color/white"
     tools:context=".presentation.ui.progress.ProgressFragment">
 
     <LinearLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:orientation="vertical">
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="24dp">
 
-
-        <FrameLayout
+        <LinearLayout
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:background="#00420840">
-
-            <View
-                android:layout_width="match_parent"
-                android:layout_height="80dp"
-                android:background="#420840" />
-
-            <FrameLayout
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:paddingTop="30dp">
-
-                <TextView
-                    android:id="@+id/btnBack"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginStart="20dp"
-                    android:text="Back"
-                    android:textColor="@color/white"
-                    android:textSize="20sp" />
-
-
-                <FrameLayout
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="20dp"
-                    android:background="#00FFFFFF">
-
-                    <ImageView
-                        android:layout_width="60dp"
-                        android:layout_height="53dp"
-                        android:layout_gravity="end"
-                        android:elevation="1dp"
-                        android:src="@drawable/settings_bg" />
-
-                    <View
-                        android:id="@+id/goldDivider"
-                        android:layout_width="match_parent"
-                        android:layout_height="3dp"
-                        android:layout_gravity="bottom"
-                        android:layout_marginBottom="20dp"
-
-                        android:background="@drawable/gradient_view"
-                        app:layout_constraintBottom_toBottomOf="parent"
-                        app:layout_constraintEnd_toEndOf="parent"
-                        app:layout_constraintStart_toStartOf="parent"
-                        app:layout_constraintTop_toTopOf="parent" />
-                </FrameLayout>
-
-            </FrameLayout>
-
-        </FrameLayout>
-
-        <TextView
-            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_gravity="center"
-            android:fontFamily="@font/inter_18pt_bold"
-            android:text="Your Progress"
-            android:textSize="25sp" />
-
-        <FrameLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content">
-
-            <ImageView
-                android:layout_width="wrap_content"
-                android:layout_height="330dp"
-                android:src="@drawable/progress_bg2" />
+            android:gravity="center_vertical"
+            android:orientation="horizontal">
 
             <TextView
-                android:id="@+id/progress_percentage"
+                android:id="@+id/btnBack"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_gravity="center"
-                android:fontFamily="@font/inter_18pt_extrabold"
-                android:text="0%"
-                android:textSize="40sp" />
-        </FrameLayout>
+                android:paddingVertical="8dp"
+                android:paddingHorizontal="16dp"
+                android:text="@string/article_back"
+                android:textColor="@color/black"
+                android:textSize="16sp"
+                android:textStyle="bold" />
 
-        <TextView
-            android:id="@+id/pomodoro_cycles"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center"
-            android:fontFamily="@font/inter_18pt_bold"
-            android:text="Pomodoro Cycles Completed: 0"
-            android:textSize="18sp" />
-
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center"
-            android:layout_marginTop="10dp"
-            android:fontFamily="@font/inter_18pt_bold"
-            android:text="Skill Mastery"
-            android:textSize="20sp" />
-
-        <FrameLayout
-            android:layout_width="match_parent"
-            android:layout_height="210dp"
-            android:layout_marginTop="10dp"
-            android:layout_marginBottom="16dp">
-
-            <ImageView
-                android:layout_width="match_parent"
+            <TextView
+                android:id="@+id/textProgressTitle"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:src="@drawable/lesson_list_bg" />
+                android:layout_marginStart="16dp"
+                android:layout_weight="1"
+                android:text="@string/progress_title"
+                android:textColor="@color/black"
+                android:textSize="24sp"
+                android:textStyle="bold" />
+        </LinearLayout>
+
+        <com.google.android.material.card.MaterialCardView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="24dp"
+            app:cardCornerRadius="20dp"
+            app:cardElevation="2dp"
+            app:strokeColor="@color/black"
+            app:strokeWidth="0.5dp">
 
             <LinearLayout
                 android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:orientation="horizontal"
-                android:padding="30dp">
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:padding="24dp">
 
-                <LinearLayout
+                <TextView
+                    android:id="@+id/textProgressHeader"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_gravity="center_vertical"
-                    android:layout_marginStart="15dp"
-                    android:layout_weight="1"
-                    android:orientation="vertical">
+                    android:text="@string/progress_overall_title"
+                    android:textColor="@color/black"
+                    android:textSize="16sp"
+                    android:textStyle="bold" />
 
-                    <TextView
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_marginBottom="10dp"
-                        android:fontFamily="@font/inter_18pt_bold"
-                        android:text="Pomodoro Trials"
-                        android:textSize="20sp" />
+                <TextView
+                    android:id="@+id/textProgressPercentage"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="12dp"
+                    android:textColor="@color/black"
+                    android:textSize="32sp"
+                    android:textStyle="bold"
+                    tools:text="80%" />
 
-                    <TextView
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:fontFamily="@font/inter_18pt_bold"
-                        android:text="9 of 12 lessons completes"
-                        android:textColor="@color/white"
-                        android:textSize="13sp" />
+                <ProgressBar
+                    android:id="@+id/progressBar"
+                    style="?android:attr/progressBarStyleHorizontal"
+                    android:layout_width="match_parent"
+                    android:layout_height="12dp"
+                    android:layout_marginTop="16dp"
+                    android:max="100"
+                    android:progress="0" />
 
-                    <LinearLayout
-                        android:layout_width="match_parent"
-                        android:layout_marginTop="10dp"
-                        android:layout_height="wrap_content"
-                        android:orientation="vertical">
-                        <TextView
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:text="45%"
-                            android:textColor="#00F8FF"
-                            android:layout_gravity="center"
-                            android:textSize="20sp"
-                            android:fontFamily="@font/inter_18pt_extrabold"/>
-
-
-                        <ProgressBar
-                            android:id="@+id/progressBar"
-                            style="?android:attr/progressBarStyleHorizontal"
-                            android:layout_width="match_parent"
-                            android:layout_height="20dp"
-                            android:layout_marginTop="5dp"
-                            android:progressDrawable="@drawable/progress_layer"
-                            android:max="100"
-                            android:progress="45"/> <!-- Прогресс 45% -->
-                        <!-- Прогресс 45% -->
-                    </LinearLayout>
-
-
-                </LinearLayout>
-
-                <ImageView
-                    android:layout_width="110dp"
-                    android:layout_height="110dp"
-                    android:layout_gravity="center_vertical|end"
-                    android:layout_marginEnd="10dp"
-                    android:src="@drawable/shield_gray" />
+                <TextView
+                    android:id="@+id/textLessonsCompleted"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="12dp"
+                    android:textColor="@color/black"
+                    android:textSize="14sp"
+                    tools:text="3 of 5 lessons completed" />
             </LinearLayout>
+        </com.google.android.material.card.MaterialCardView>
 
+        <TextView
+            android:id="@+id/textSkillSection"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="32dp"
+            android:text="@string/progress_skill_section"
+            android:textColor="@color/black"
+            android:textSize="18sp"
+            android:textStyle="bold" />
 
-        </FrameLayout>
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/skillProgressList"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            android:nestedScrollingEnabled="false"
+            tools:listitem="@layout/item_skill_progress" />
+
+        <TextView
+            android:id="@+id/textNoSkills"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            android:text="@string/progress_no_skills"
+            android:textColor="@color/black"
+            android:textSize="14sp"
+            android:visibility="gone"
+            tools:visibility="gone" />
+
+        <com.google.android.material.card.MaterialCardView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="32dp"
+            app:cardCornerRadius="20dp"
+            app:cardElevation="2dp"
+            app:strokeColor="@color/black"
+            app:strokeWidth="0.5dp">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:padding="24dp">
+
+                <TextView
+                    android:id="@+id/pomodoro_cycles"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:textColor="@color/black"
+                    android:textSize="16sp"
+                    android:textStyle="bold"
+                    tools:text="Pomodoro Cycles Completed: 4" />
+
+                <ProgressBar
+                    android:id="@+id/pomodoroProgress"
+                    style="?android:attr/progressBarStyleHorizontal"
+                    android:layout_width="match_parent"
+                    android:layout_height="10dp"
+                    android:layout_marginTop="12dp"
+                    android:max="12"
+                    android:progress="0" />
+            </LinearLayout>
+        </com.google.android.material.card.MaterialCardView>
+
+        <TextView
+            android:id="@+id/textMotivation"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="32dp"
+            android:layout_marginBottom="32dp"
+            android:text="@string/progress_motivation"
+            android:textColor="@color/black"
+            android:textSize="16sp" />
     </LinearLayout>
 
 </ScrollView>
+

--- a/app/src/main/res/layout/item_skill_progress.xml
+++ b/app/src/main/res/layout/item_skill_progress.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginTop="12dp"
+    android:clickable="true"
+    android:focusable="true"
+    android:foreground="?attr/selectableItemBackground"
+    app:cardCornerRadius="16dp"
+    app:cardElevation="2dp"
+    app:strokeColor="@color/black"
+    app:strokeWidth="0.5dp">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="20dp">
+
+        <TextView
+            android:id="@+id/textSkillTitle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textColor="@color/black"
+            android:textSize="18sp"
+            android:textStyle="bold" />
+
+        <TextView
+            android:id="@+id/textSkillLessons"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:textColor="@color/black"
+            android:textSize="14sp" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            android:gravity="center_vertical"
+            android:orientation="horizontal">
+
+            <ProgressBar
+                android:id="@+id/skillProgressBar"
+                style="?android:attr/progressBarStyleHorizontal"
+                android:layout_width="0dp"
+                android:layout_height="8dp"
+                android:layout_weight="1"
+                android:max="100"
+                android:progress="0" />
+
+            <TextView
+                android:id="@+id/textSkillPercent"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="12dp"
+                android:textColor="@color/black"
+                android:textSize="14sp"
+                android:textStyle="bold" />
+        </LinearLayout>
+    </LinearLayout>
+
+</com.google.android.material.card.MaterialCardView>
+

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -55,6 +55,10 @@
         android:name="sr.otaryp.tesatyla.presentation.ui.lessons.LessonListFragment"
         android:label="Lessons"
         tools:layout="@layout/fragment_lesson_list">
+        <argument
+            android:name="skillId"
+            app:argType="string"
+            android:defaultValue="" />
         <action
             android:id="@+id/action_nav_lessons_to_nav_home"
             app:destination="@id/nav_home"
@@ -78,7 +82,11 @@
         android:id="@+id/nav_progress"
         android:name="sr.otaryp.tesatyla.presentation.ui.progress.ProgressFragment"
         android:label="Progress"
-        tools:layout="@layout/fragment_progress" />
+        tools:layout="@layout/fragment_progress">
+        <action
+            android:id="@+id/action_nav_progress_to_nav_lessons"
+            app:destination="@id/nav_lessons" />
+    </fragment>
 
     <fragment
         android:id="@+id/nav_focus"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -55,6 +55,7 @@ Your quests await.</string>
     <string name="lesson_step_detail_title_format">Step %1$d: %2$s</string>
     <string name="lesson_step_locked_detail">Finish the previous quest step to unlock this challenge.</string>
     <string name="lesson_step_completed_message">Quest step completed! Return to the hall to keep progressing.</string>
+    <string name="lesson_list_title_all">All Lessons</string>
 
     <string name="victory_next_lesson">Next Lesson</string>
     <string name="victory_replay_lesson">Replay Lesson</string>
@@ -94,4 +95,10 @@ Your quests await.</string>
     <string name="focus_break_complete_message">Break over! Ready for your next focus quest.</string>
     <string name="progress_percentage_format">%1$d%%</string>
     <string name="progress_cycles_format">Pomodoro Cycles Completed: %1$d</string>
+    <string name="progress_lessons_completed">%1$d of %2$d lessons completed</string>
+    <string name="progress_title">Your Progress</string>
+    <string name="progress_overall_title">Overall Progress</string>
+    <string name="progress_skill_section">Skill Progress</string>
+    <string name="progress_no_skills">No skills to display yet.</string>
+    <string name="progress_motivation">Keep going! Every lesson makes your kingdom stronger.</string>
 </resources>


### PR DESCRIPTION
## Summary
- implement a dedicated ProgressViewModel and adapter to expose overall completion, skill breakdowns, and pomodoro counts
- redesign ProgressFragment with progress cards, skill list, and motivation copy wired to real data
- add a skill catalog and lesson list filtering so tapping a skill opens the relevant lessons

## Testing
- ./gradlew :app:assembleDebug *(fails: Android SDK not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dfac37cfd4832aa1d755e6ef4528e4