### PR TITLE
Implement progress tracking visuals

### DIFF
--- a/app/src/main/java/sr/otaryp/tesatyla/data/lessons/SkillCatalog.kt
+++ b/app/src/main/java/sr/otaryp/tesatyla/data/lessons/SkillCatalog.kt
@@ -14,23 +14,13 @@ object SkillCatalog {
         val lessonIds: List<Int>,
     )
 
-    val skills: List<Skill> = listOf(
+    val skills: List<Skill> = LessonSeedData.lessons.map { lesson ->
         Skill(
-            id = "focus",
-            title = "Focus & Distraction Shield",
-            lessonIds = listOf(1, 3),
-        ),
-        Skill(
-            id = "planning",
-            title = "Planning & Time Mastery",
-            lessonIds = listOf(2, 4),
-        ),
-        Skill(
-            id = "momentum",
-            title = "Momentum & Motivation",
-            lessonIds = listOf(5),
-        ),
-    )
+            id = lesson.id.toString(),
+            title = lesson.title.substringAfter(": ", lesson.title).trim(),
+            lessonIds = listOf(lesson.id),
+        )
+    }
 
     fun findSkill(skillId: String?): Skill? {
         if (skillId.isNullOrBlank()) return null

--- a/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/progress/ProgressFragment.kt
+++ b/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/progress/ProgressFragment.kt
@@ -71,14 +71,12 @@ class ProgressFragment : Fragment() {
 
     private fun renderState(state: ProgressUiState) = with(binding) {
         textProgressPercentage.text = getString(R.string.progress_percentage_format, state.overallPercent)
-//        textLessonsCompleted.text = getString(
-//            R.string.progress_lessons_completed,
-//            state.completedLessons,
-//            state.totalLessons,
-//        )
-//        progressBar.progress = state.overallPercent
+        textLessonsCompleted.text = getString(
+            R.string.progress_lessons_completed,
+            state.completedLessons,
+            state.totalLessons,
+        )
         pomodoroCycles.text = getString(R.string.progress_cycles_format, state.pomodoroCycles)
-//        pomodoroProgress.progress = state.pomodoroCycles.coerceAtMost(ProgressViewModel.DAILY_POMODORO_GOAL)
 
         skillAdapter.submitList(state.skills)
         skillProgressList.isVisible = state.skills.isNotEmpty()

--- a/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/progress/ProgressViewModel.kt
+++ b/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/progress/ProgressViewModel.kt
@@ -36,12 +36,14 @@ class ProgressViewModel(
 
                 val total = skillLessons.size
                 val completed = skillLessons.count { it.lesson.isCompleted }
+                val isComplete = total > 0 && completed == total
                 SkillProgressItem(
                     id = skill.id,
                     title = skill.title,
                     completedLessons = completed,
                     totalLessons = total,
                     completionPercent = if (total == 0) 0 else ((completed.toFloat() / total) * 100).roundToInt(),
+                    isComplete = isComplete,
                 )
             }
 
@@ -113,5 +115,6 @@ data class SkillProgressItem(
     val completedLessons: Int,
     val totalLessons: Int,
     val completionPercent: Int,
+    val isComplete: Boolean,
 )
 

--- a/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/progress/SkillProgressAdapter.kt
+++ b/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/progress/SkillProgressAdapter.kt
@@ -41,6 +41,12 @@ class SkillProgressAdapter(
             )
             binding.skillProgressBar.max = 100
             binding.skillProgressBar.progress = item.completionPercent
+            val statusDrawable = if (item.isComplete) {
+                R.drawable.shield_bg
+            } else {
+                R.drawable.shield_gray
+            }
+            binding.statusIm.setImageResource(statusDrawable)
 
             binding.root.setOnClickListener { onSkillSelected(item) }
         }

--- a/app/src/main/res/layout/fragment_progress.xml
+++ b/app/src/main/res/layout/fragment_progress.xml
@@ -95,6 +95,18 @@
         </FrameLayout>
 
         <TextView
+            android:id="@+id/textLessonsCompleted"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:layout_marginTop="8dp"
+            android:fontFamily="@font/inter_18pt_bold"
+            android:text="@string/progress_lessons_completed"
+            android:textColor="@color/white"
+            android:textSize="16sp"
+            tools:text="4 of 10 lessons completed" />
+
+        <TextView
             android:id="@+id/pomodoroCycles"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"

--- a/app/src/main/res/layout/item_skill_progress.xml
+++ b/app/src/main/res/layout/item_skill_progress.xml
@@ -75,6 +75,7 @@
         </LinearLayout>
 
         <ImageView
+            android:id="@+id/statusIm"
             android:layout_width="110dp"
             android:layout_height="110dp"
             android:layout_gravity="center_vertical|end"


### PR DESCRIPTION
## Summary
- derive progress skill cards directly from lesson seed data so topics match the available lessons
- surface overall lesson completion totals alongside the percent indicator on the progress screen
- show per-skill completion shields that react to progress

## Testing
- ./gradlew test *(fails: Android SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dfc1a7a7e0832a908863009863fffa