### PR TITLE
Add interactive settings screen actions

### DIFF
--- a/app/src/main/java/sr/otaryp/tesatyla/data/preferences/FocusPreferences.kt
+++ b/app/src/main/java/sr/otaryp/tesatyla/data/preferences/FocusPreferences.kt
@@ -58,4 +58,10 @@ object FocusPreferences {
             0
         }
     }
+
+    fun clear(context: Context) {
+        sharedPreferences(context).edit {
+            clear()
+        }
+    }
 }

--- a/app/src/main/java/sr/otaryp/tesatyla/data/preferences/LaunchPreferences.kt
+++ b/app/src/main/java/sr/otaryp/tesatyla/data/preferences/LaunchPreferences.kt
@@ -18,4 +18,10 @@ object LaunchPreferences {
             putBoolean(KEY_ONBOARDING_COMPLETE, true)
         }
     }
+
+    fun clear(context: Context) {
+        context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE).edit {
+            clear()
+        }
+    }
 }

--- a/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/settings/PrivacyPolicyFragment.kt
+++ b/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/settings/PrivacyPolicyFragment.kt
@@ -1,0 +1,28 @@
+package sr.otaryp.tesatyla.presentation.ui.settings
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import sr.otaryp.tesatyla.databinding.FragmentPrivacyPolicyBinding
+
+class PrivacyPolicyFragment : Fragment() {
+
+    private var _binding: FragmentPrivacyPolicyBinding? = null
+    private val binding get() = _binding!!
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View {
+        _binding = FragmentPrivacyPolicyBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+}

--- a/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/settings/SettingsFragment.kt
+++ b/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/settings/SettingsFragment.kt
@@ -1,60 +1,116 @@
 package sr.otaryp.tesatyla.presentation.ui.settings
 
+import android.content.ActivityNotFoundException
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
 import android.os.Bundle
-import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Toast
+import androidx.appcompat.app.AlertDialog
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.lifecycleScope
+import androidx.navigation.fragment.findNavController
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import sr.otaryp.tesatyla.R
+import sr.otaryp.tesatyla.data.lessons.LessonDatabase
+import sr.otaryp.tesatyla.data.preferences.FocusPreferences
+import sr.otaryp.tesatyla.data.preferences.LaunchPreferences
+import sr.otaryp.tesatyla.data.preferences.LessonProgressPreferences
+import sr.otaryp.tesatyla.databinding.FragmentSettingsBinding
 
-// TODO: Rename parameter arguments, choose names that match
-// the fragment initialization parameters, e.g. ARG_ITEM_NUMBER
-private const val ARG_PARAM1 = "param1"
-private const val ARG_PARAM2 = "param2"
-
-/**
- * A simple [Fragment] subclass.
- * Use the [SettingsFragment.newInstance] factory method to
- * create an instance of this fragment.
- */
 class SettingsFragment : Fragment() {
-    // TODO: Rename and change types of parameters
-    private var param1: String? = null
-    private var param2: String? = null
 
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        arguments?.let {
-            param1 = it.getString(ARG_PARAM1)
-            param2 = it.getString(ARG_PARAM2)
+    private var _binding: FragmentSettingsBinding? = null
+    private val binding get() = _binding!!
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View {
+        _binding = FragmentSettingsBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        setupClickListeners()
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+
+    private fun setupClickListeners() {
+        binding.buttonShareApp.setOnClickListener { shareApp() }
+        binding.buttonRateUs.setOnClickListener { openStorePage() }
+        binding.buttonPrivacyPolicy.setOnClickListener { openPrivacyPolicy() }
+        binding.buttonTerms.setOnClickListener { openTermsAndConditions() }
+        binding.buttonClearData.setOnClickListener { confirmClearAppData() }
+    }
+
+    private fun shareApp() {
+        val packageName = requireContext().packageName
+        val shareMessage = getString(R.string.settings_share_message, packageName)
+        val shareIntent = Intent(Intent.ACTION_SEND).apply {
+            type = "text/plain"
+            putExtra(Intent.EXTRA_TEXT, shareMessage)
+        }
+        startActivity(Intent.createChooser(shareIntent, getString(R.string.settings_share_chooser_title)))
+    }
+
+    private fun openStorePage() {
+        val packageName = requireContext().packageName
+        val playStoreUri = Uri.parse("market://details?id=$packageName")
+        val marketIntent = Intent(Intent.ACTION_VIEW, playStoreUri)
+        try {
+            startActivity(marketIntent)
+        } catch (error: ActivityNotFoundException) {
+            val webUri = Uri.parse("https://play.google.com/store/apps/details?id=$packageName")
+            startActivity(Intent(Intent.ACTION_VIEW, webUri))
         }
     }
 
-    override fun onCreateView(
-        inflater: LayoutInflater, container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View? {
-        // Inflate the layout for this fragment
-        return inflater.inflate(R.layout.fragment_settings, container, false)
+    private fun openPrivacyPolicy() {
+        findNavController().navigate(R.id.action_settingsFragment_to_privacyPolicyFragment)
     }
 
-    companion object {
-        /**
-         * Use this factory method to create a new instance of
-         * this fragment using the provided parameters.
-         *
-         * @param param1 Parameter 1.
-         * @param param2 Parameter 2.
-         * @return A new instance of fragment SettingsFragment.
-         */
-        // TODO: Rename and change types and number of parameters
-        @JvmStatic
-        fun newInstance(param1: String, param2: String) =
-            SettingsFragment().apply {
-                arguments = Bundle().apply {
-                    putString(ARG_PARAM1, param1)
-                    putString(ARG_PARAM2, param2)
-                }
+    private fun openTermsAndConditions() {
+        findNavController().navigate(R.id.action_settingsFragment_to_termsConditionsFragment)
+    }
+
+    private fun confirmClearAppData() {
+        AlertDialog.Builder(requireContext())
+            .setTitle(R.string.settings_clear_data_confirm_title)
+            .setMessage(R.string.settings_clear_data_confirm_message)
+            .setPositiveButton(R.string.settings_clear_data_confirm_positive) { dialog, _ ->
+                dialog.dismiss()
+                clearAppData()
             }
+            .setNegativeButton(R.string.settings_clear_data_confirm_negative, null)
+            .show()
+    }
+
+    private fun clearAppData() {
+        val appContext = requireContext().applicationContext
+        viewLifecycleOwner.lifecycleScope.launch {
+            withContext(Dispatchers.IO) {
+                LessonDatabase.getInstance(appContext).clearAllTables()
+                clearPreferences(appContext)
+            }
+            Toast.makeText(requireContext(), R.string.settings_clear_data_success, Toast.LENGTH_SHORT).show()
+        }
+    }
+
+    private fun clearPreferences(context: Context) {
+        LaunchPreferences.clear(context)
+        FocusPreferences.clear(context)
+        LessonProgressPreferences.clear(context)
     }
 }

--- a/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/settings/TermsConditionsFragment.kt
+++ b/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/settings/TermsConditionsFragment.kt
@@ -1,0 +1,28 @@
+package sr.otaryp.tesatyla.presentation.ui.settings
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import sr.otaryp.tesatyla.databinding.FragmentTermsConditionsBinding
+
+class TermsConditionsFragment : Fragment() {
+
+    private var _binding: FragmentTermsConditionsBinding? = null
+    private val binding get() = _binding!!
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View {
+        _binding = FragmentTermsConditionsBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+}

--- a/app/src/main/res/layout/fragment_privacy_policy.xml
+++ b/app/src/main/res/layout/fragment_privacy_policy.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:gravity="center"
+    android:padding="32dp"
+    android:background="@color/white"
+    tools:context=".presentation.ui.settings.PrivacyPolicyFragment">
+
+    <TextView
+        android:id="@+id/textTitle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/privacy_policy_placeholder_title"
+        android:textColor="@color/black"
+        android:textSize="22sp"
+        android:textStyle="bold"
+        android:layout_marginBottom="16dp" />
+
+    <TextView
+        android:id="@+id/textMessage"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/privacy_policy_placeholder_message"
+        android:textAlignment="center"
+        android:textColor="@color/black"
+        android:textSize="16sp" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/fragment_settings.xml
+++ b/app/src/main/res/layout/fragment_settings.xml
@@ -1,14 +1,77 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:padding="24dp"
+    android:background="@color/white"
     tools:context=".presentation.ui.settings.SettingsFragment">
 
-    <!-- TODO: Update blank fragment layout -->
-    <TextView
+    <LinearLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:text="@string/hello_blank_fragment" />
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:gravity="center_horizontal">
 
-</FrameLayout>
+        <TextView
+            android:id="@+id/textTitle"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/settings_title"
+            android:textAlignment="center"
+            android:textColor="@color/black"
+            android:textSize="24sp"
+            android:textStyle="bold"
+            android:layout_marginBottom="24dp" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/buttonShareApp"
+            style="@style/Widget.MaterialComponents.Button.OutlinedButton"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/settings_share_app" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/buttonRateUs"
+            style="@style/Widget.MaterialComponents.Button.OutlinedButton"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/settings_rate_us"
+            android:layout_marginTop="12dp" />
+
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:layout_marginVertical="24dp"
+            android:background="@color/settings_divider" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/buttonPrivacyPolicy"
+            style="@style/Widget.MaterialComponents.Button.TextButton"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/settings_privacy_policy" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/buttonTerms"
+            style="@style/Widget.MaterialComponents.Button.TextButton"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/settings_terms_conditions"
+            android:layout_marginTop="12dp" />
+
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:layout_marginVertical="24dp"
+            android:background="@color/settings_divider" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/buttonClearData"
+            style="@style/Widget.MaterialComponents.Button"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/settings_clear_data" />
+
+    </LinearLayout>
+</ScrollView>

--- a/app/src/main/res/layout/fragment_terms_conditions.xml
+++ b/app/src/main/res/layout/fragment_terms_conditions.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:gravity="center"
+    android:padding="32dp"
+    android:background="@color/white"
+    tools:context=".presentation.ui.settings.TermsConditionsFragment">
+
+    <TextView
+        android:id="@+id/textTitle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/terms_conditions_placeholder_title"
+        android:textColor="@color/black"
+        android:textSize="22sp"
+        android:textStyle="bold"
+        android:layout_marginBottom="16dp" />
+
+    <TextView
+        android:id="@+id/textMessage"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/terms_conditions_placeholder_message"
+        android:textAlignment="center"
+        android:textColor="@color/black"
+        android:textSize="16sp" />
+
+</LinearLayout>

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -156,4 +156,29 @@
             app:argType="string" />
     </fragment>
 
+    <fragment
+        android:id="@+id/settingsFragment"
+        android:name="sr.otaryp.tesatyla.presentation.ui.settings.SettingsFragment"
+        android:label="Settings"
+        tools:layout="@layout/fragment_settings">
+        <action
+            android:id="@+id/action_settingsFragment_to_privacyPolicyFragment"
+            app:destination="@id/privacyPolicyFragment" />
+        <action
+            android:id="@+id/action_settingsFragment_to_termsConditionsFragment"
+            app:destination="@id/termsConditionsFragment" />
+    </fragment>
+
+    <fragment
+        android:id="@+id/privacyPolicyFragment"
+        android:name="sr.otaryp.tesatyla.presentation.ui.settings.PrivacyPolicyFragment"
+        android:label="Privacy Policy"
+        tools:layout="@layout/fragment_privacy_policy" />
+
+    <fragment
+        android:id="@+id/termsConditionsFragment"
+        android:name="sr.otaryp.tesatyla.presentation.ui.settings.TermsConditionsFragment"
+        android:label="Terms and Conditions"
+        tools:layout="@layout/fragment_terms_conditions" />
+
 </navigation>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -6,4 +6,5 @@
     <color name="step_card_stroke">#E2B886</color>
     <color name="step_card_background_completed">#FFE6B4</color>
     <color name="step_card_stroke_completed">#FFC25A</color>
+    <color name="settings_divider">#FFE0E0E0</color>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -102,4 +102,22 @@ Your quests await.</string>
     <string name="progress_skill_section">Skill Progress</string>
     <string name="progress_no_skills">No skills to display yet.</string>
     <string name="progress_motivation">Keep going! Every lesson makes your kingdom stronger.</string>
+
+    <string name="settings_title">Settings</string>
+    <string name="settings_share_app">Share the App</string>
+    <string name="settings_rate_us">Rate Us</string>
+    <string name="settings_privacy_policy">Privacy Policy</string>
+    <string name="settings_terms_conditions">Terms and Conditions</string>
+    <string name="settings_clear_data">Clear App data</string>
+    <string name="settings_share_message">Upgrade your skill in Total Shine app: http://play.google.com/store/apps/details?id=%1$s</string>
+    <string name="settings_share_chooser_title">Share via</string>
+    <string name="settings_clear_data_confirm_title">Clear all data?</string>
+    <string name="settings_clear_data_confirm_message">This will remove your saved progress and preferences. Continue?</string>
+    <string name="settings_clear_data_confirm_positive">Clear</string>
+    <string name="settings_clear_data_confirm_negative">Cancel</string>
+    <string name="settings_clear_data_success">All app data has been cleared.</string>
+    <string name="privacy_policy_placeholder_title">Privacy Policy</string>
+    <string name="privacy_policy_placeholder_message">Your privacy matters to us. The detailed policy will appear here soon.</string>
+    <string name="terms_conditions_placeholder_title">Terms &amp; Conditions</string>
+    <string name="terms_conditions_placeholder_message">The full terms and conditions will be available on this screen in a future update.</string>
 </resources>


### PR DESCRIPTION
## Summary
- replace the placeholder settings layout with actionable buttons for sharing, rating, policy links, and data clearing
- add placeholder fragments and navigation targets for the privacy policy and terms & conditions screens
- provide preference clearing helpers so the clear-data action also wipes stored progress

## Testing
- ./gradlew test *(fails: Android SDK not configured in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dfe39684bc832ab4f7d87c1666d008