### PR TITLE
Make royal quest dialog background transparent

### DIFF
--- a/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/main/HomeFragment.kt
+++ b/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/main/HomeFragment.kt
@@ -1,7 +1,8 @@
 package sr.otaryp.tesatyla.presentation.ui.main
 
+import android.graphics.Color
+import android.graphics.drawable.ColorDrawable
 import android.os.Bundle
-
 import android.view.LayoutInflater
 import android.view.MotionEvent
 import android.view.View
@@ -94,6 +95,8 @@ class HomeFragment : Fragment() {
             .setView(dialogBinding.root)
             .setCancelable(true)
             .create()
+
+        dialog.window?.setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))
 
         // Кнопка "Got it" закрывает окно
         dialogBinding.buttonClose.setOnClickListener { dialog.dismiss() }

--- a/app/src/main/res/layout/dialog_set_royal_quest.xml
+++ b/app/src/main/res/layout/dialog_set_royal_quest.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="wrap_content"
-    android:background="#00000000"
-    android:layout_height="wrap_content">
+    android:layout_height="wrap_content"
+    android:background="@android:color/transparent">
 
     <ImageView
         android:layout_width="wrap_content"
@@ -40,7 +40,8 @@
 
 
         <androidx.appcompat.widget.AppCompatButton
-            android:id="@+id/buttonNext"            android:layout_width="wrap_content"
+            android:id="@+id/buttonNext"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="10dp"
             android:background="@drawable/btn_enter_kingdom"
@@ -56,7 +57,8 @@
             android:textStyle="bold" />
 
         <androidx.appcompat.widget.AppCompatButton
-            android:id="@+id/buttonClose"            android:layout_width="wrap_content"
+            android:id="@+id/buttonClose"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:background="@drawable/btn_enter_kingdom"
             android:includeFontPadding="false"


### PR DESCRIPTION
## Summary
- remove the white background around the royal quest dialog by setting the window background to transparent
- ensure the dialog layout explicitly uses a transparent root background and tidy up misformatted attributes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dfe38c8824832abf38217bacfcb4ee