### PR TITLE
Fix Material style references to resolve resource linking errors

### DIFF
--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -8,12 +8,14 @@
         <item name="fontFamily">@font/katibeh_regular</item>
     </style>
 
+    <style name="Shape" />
+
     <style name="Shape.Pill">
         <item name="cornerFamily">rounded</item>
         <item name="cornerSize">50%</item>
     </style>
 
-    <style name="BottomNavLabelActive" parent="@style/TextAppearance.MaterialComponents.LabelMedium">
+    <style name="BottomNavLabelActive" parent="@style/TextAppearance.Material3.LabelMedium">
         <item name="android:textColor">@android:color/white</item>
         <item name="android:background">@drawable/bottom_nav_label_background</item>
         <item name="android:paddingLeft">12dp</item>
@@ -22,7 +24,7 @@
         <item name="android:paddingBottom">4dp</item>
     </style>
 
-    <style name="BottomNavLabelInactive" parent="@style/TextAppearance.MaterialComponents.LabelMedium">
+    <style name="BottomNavLabelInactive" parent="@style/TextAppearance.Material3.LabelMedium">
         <item name="android:textColor">#FFD700</item>
         <item name="android:background">@android:color/transparent</item>
         <item name="android:paddingLeft">12dp</item>
@@ -32,7 +34,7 @@
     </style>
 
     <!-- Legacy style reference used by menu previews -->
-    <style name="BottomNavTextAppearance" parent="@style/TextAppearance.MaterialComponents.LabelMedium">
+    <style name="BottomNavTextAppearance" parent="@style/TextAppearance.Material3.LabelMedium">
         <item name="android:textColor">#FFD700</item>
     </style>
 


### PR DESCRIPTION
## Summary
- update bottom navigation text appearance styles to use the Material3 label typography
- add a base Shape style so the Shape.Pill overlay no longer inherits from a missing parent

## Testing
- ⚠️ `./gradlew assembleDebug` *(fails: SDK location not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e0079124fc832a8df4c52fd4373e4e