### PR TITLE
Fix null custom bottom nav initialization

### DIFF
--- a/app/src/main/java/sr/otaryp/tesatyla/MainActivity.kt
+++ b/app/src/main/java/sr/otaryp/tesatyla/MainActivity.kt
@@ -7,12 +7,14 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.isVisible
+import androidx.navigation.NavController
+import androidx.navigation.NavOptions
 import androidx.navigation.fragment.NavHostFragment
-import androidx.navigation.ui.setupWithNavController
-import com.google.android.material.bottomnavigation.BottomNavigationView
 import sr.otaryp.tesatyla.presentation.ui.setupCustomBottomNav
 
 class MainActivity : AppCompatActivity() {
+    private lateinit var navController: NavController
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
@@ -22,14 +24,9 @@ class MainActivity : AppCompatActivity() {
             v.setPadding(systemBars.left, systemBars.top, systemBars.right, systemBars.bottom)
             insets
         }
-
-
         val navHostFragment = supportFragmentManager
             .findFragmentById(R.id.nav_host_fragment) as NavHostFragment
-        val navController = navHostFragment.navController
-
-        val bottomNavigation = findViewById<BottomNavigationView>(R.id.bottom_nav)
-        bottomNavigation.setupWithNavController(navController)
+        navController = navHostFragment.navController
 
         val destinationsWithBottomNav = setOf(
             R.id.nav_home,
@@ -39,20 +36,44 @@ class MainActivity : AppCompatActivity() {
             R.id.nav_focus
         )
 
+        val bottomNav = findViewById<View>(R.id.customBottomNav)
+
         navController.addOnDestinationChangedListener { _, destination, _ ->
-            bottomNavigation.isVisible = destination.id in destinationsWithBottomNav
+            bottomNav?.isVisible = destination.id in destinationsWithBottomNav
         }
 
-        val bottomNav = findViewById<View>(R.id.customBottomNav)
-        bottomNav.setupCustomBottomNav { index ->
-            when (index) {
-                0 -> openHome()
-                1 -> openLessons()
-                2 -> openArticles()
-                3 -> openProgress()
-                4 -> openFocus()
+        bottomNav?.let { view ->
+            view.setupCustomBottomNav { index ->
+                when (index) {
+                    0 -> openHome()
+                    1 -> openLessons()
+                    2 -> openArticles()
+                    3 -> openProgress()
+                    4 -> openFocus()
+                }
             }
         }
     }
+
+    private fun openHome() = navigateToRootDestination(R.id.nav_home)
+
+    private fun openLessons() = navigateToRootDestination(R.id.nav_lessons)
+
+    private fun openArticles() = navigateToRootDestination(R.id.nav_articles)
+
+    private fun openProgress() = navigateToRootDestination(R.id.nav_progress)
+
+    private fun openFocus() = navigateToRootDestination(R.id.nav_focus)
+
+    private fun navigateToRootDestination(destinationId: Int) {
+        if (!::navController.isInitialized) return
+        if (navController.currentDestination?.id == destinationId) return
+
+        val navOptions = NavOptions.Builder()
+            .setLaunchSingleTop(true)
+            .setPopUpTo(R.id.nav_graph, false)
+            .build()
+
+        navController.navigate(destinationId, null, navOptions)
     }
 }


### PR DESCRIPTION
## Summary
- guard the custom bottom navigation view lookup to avoid crashes when it is absent
- use the custom bottom navigation view for visibility control and navigation callbacks

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e00d522c78832aa00069c1d5d83ed0