### PR TITLE
Fix step header, article list length, and progress counts

### DIFF
--- a/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/lessons/LessonStepDetailFragment.kt
+++ b/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/lessons/LessonStepDetailFragment.kt
@@ -71,11 +71,10 @@ class LessonStepDetailFragment : Fragment() {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 viewModel.uiState.collect { state ->
                     binding.tvLessonTitle.text = state.lessonTitle
-                    val formattedTitle = if (state.stepNumber > 0 && state.stepTitle.isNotBlank()) {
+                    val formattedTitle = if (state.stepNumber > 0) {
                         getString(
-                            R.string.lesson_step_detail_title_format,
-                            state.stepNumber,
-                            state.stepTitle
+                            R.string.lesson_step_detail_step_number_format,
+                            state.stepNumber
                         )
                     } else {
                         state.stepTitle

--- a/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/progress/ProgressViewModel.kt
+++ b/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/progress/ProgressViewModel.kt
@@ -36,8 +36,10 @@ class ProgressViewModel(
                 val skillLessons = lessons.filter { skill.lessonIds.contains(it.lesson.id) }
                 if (skillLessons.isEmpty()) return@mapNotNull null
 
-                val total = skillLessons.size
-                val completed = skillLessons.count { it.lesson.isCompleted }
+                val total = skillLessons.sumOf { it.steps.size }
+                val completed = skillLessons.sumOf { lesson ->
+                    lesson.steps.count { it.isCompleted }
+                }
                 val isComplete = total > 0 && completed == total
                 SkillProgressItem(
                     id = skill.id,

--- a/app/src/main/res/layout/fragment_article.xml
+++ b/app/src/main/res/layout/fragment_article.xml
@@ -98,7 +98,7 @@
             android:layout_marginBottom="20dp"
             tools:listitem="@layout/article_item"
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
+            android:layout_height="wrap_content"
             android:layout_marginHorizontal="20dp"/>
     </LinearLayout>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -52,6 +52,7 @@
     <string name="lesson_step_complete">Complete the Quest</string>
     <string name="lesson_step_completed_button">Quest Completed</string>
     <string name="lesson_step_detail_title_format">Step %1$d: %2$s</string>
+    <string name="lesson_step_detail_step_number_format">Step %1$d</string>
     <string name="lesson_step_locked_detail">Finish the previous quest step to unlock this challenge.</string>
     <string name="lesson_step_completed_message">Quest step completed! Return to the hall to keep progressing.</string>
     <string name="lesson_list_title_all">All Lessons</string>


### PR DESCRIPTION
## Summary
- show only the step number in the lesson step detail title
- allow the article list to render all items within the scroll view
- compute skill progress using completed lesson steps

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e1282671b4832a8d72f7cf842e7b18