### PR TITLE
Show splash screen only once and hide bottom bar

### DIFF
--- a/app/src/main/java/sr/otaryp/tesatyla/data/preferences/LaunchPreferences.kt
+++ b/app/src/main/java/sr/otaryp/tesatyla/data/preferences/LaunchPreferences.kt
@@ -7,6 +7,7 @@ object LaunchPreferences {
 
     private const val PREFS_NAME = "launch_preferences"
     private const val KEY_ONBOARDING_COMPLETE = "onboarding_complete"
+    private const val KEY_SPLASH_SHOWN = "splash_shown"
 
     fun isOnboardingComplete(context: Context): Boolean {
         return context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
@@ -16,6 +17,17 @@ object LaunchPreferences {
     fun setOnboardingComplete(context: Context) {
         context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE).edit {
             putBoolean(KEY_ONBOARDING_COMPLETE, true)
+        }
+    }
+
+    fun isSplashShown(context: Context): Boolean {
+        return context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .getBoolean(KEY_SPLASH_SHOWN, false)
+    }
+
+    fun setSplashShown(context: Context) {
+        context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE).edit {
+            putBoolean(KEY_SPLASH_SHOWN, true)
         }
     }
 


### PR DESCRIPTION
## Summary
- track whether the splash screen has already been displayed and skip it on subsequent launches
- update the splash fragment to hide the custom bottom navigation container and reuse shared navigation logic

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e132b6889c832a9cc67b7c96d3e695