### PR TITLE
Enable settings navigation from toolbar icons

### DIFF
--- a/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/VictoryHallFragment.kt
+++ b/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/VictoryHallFragment.kt
@@ -51,6 +51,9 @@ class VictoryHallFragment : Fragment() {
 
     private fun setupToolbar() {
         binding.btnBack.setOnClickListener { findNavController().navigateUp() }
+        binding.imageSettings.setOnClickListener {
+            findNavController().navigate(R.id.action_global_settingsFragment)
+        }
     }
 
     private fun setupButtons() {

--- a/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/article/ArticleDetailFragment.kt
+++ b/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/article/ArticleDetailFragment.kt
@@ -7,6 +7,7 @@ import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
+import sr.otaryp.tesatyla.R
 import sr.otaryp.tesatyla.databinding.FragmentArticleDetailBinding
 import sr.otaryp.tesatyla.presentation.ui.lessons.applyVerticalGradient
 
@@ -29,6 +30,9 @@ class ArticleDetailFragment : Fragment() {
         binding.textArticleTitle.text = args.articleTitle
         binding.textArticleContent.text = args.articleContent
         binding.btnBack.setOnClickListener { findNavController().popBackStack() }
+        binding.imageSettings.setOnClickListener {
+            findNavController().navigate(R.id.action_global_settingsFragment)
+        }
 
         binding.textArticleTitle.applyVerticalGradient()
     }

--- a/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/article/ArticleFragment.kt
+++ b/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/article/ArticleFragment.kt
@@ -36,6 +36,7 @@ class ArticleFragment : Fragment() {
         setupRecyclerView()
         setupSearchBar()
         setupBackButton()
+        setupSettingsButton()
 
         // стартовый список
         showArticles(allArticles)
@@ -76,6 +77,12 @@ class ArticleFragment : Fragment() {
             // если экран живёт в нижней навигации — можно вернуть на home
             // findNavController().navigate(R.id.nav_home)
             findNavController().navigateUp()
+        }
+    }
+
+    private fun setupSettingsButton() {
+        binding.imageSettings.setOnClickListener {
+            findNavController().navigate(R.id.action_global_settingsFragment)
         }
     }
 

--- a/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/lessons/LessonDetailFragment.kt
+++ b/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/lessons/LessonDetailFragment.kt
@@ -58,6 +58,9 @@ class LessonDetailFragment : Fragment() {
 
     private fun setupToolbar() {
         binding.btnBack.setOnClickListener { findNavController().navigateUp() }
+        binding.imageSettings.setOnClickListener {
+            findNavController().navigate(R.id.action_global_settingsFragment)
+        }
     }
 
     private fun setupRecyclerView() {

--- a/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/lessons/LessonListFragment.kt
+++ b/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/lessons/LessonListFragment.kt
@@ -84,6 +84,9 @@ class LessonListFragment : Fragment() {
             findNavController().navigateUp()
         }
         val skill = SkillCatalog.findSkill(args.skillId)
+        binding.imageSettings.setOnClickListener {
+            findNavController().navigate(R.id.action_global_settingsFragment)
+        }
     }
 
     private fun setupRecyclerView() {

--- a/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/lessons/LessonStepDetailFragment.kt
+++ b/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/lessons/LessonStepDetailFragment.kt
@@ -58,6 +58,9 @@ class LessonStepDetailFragment : Fragment() {
 
     private fun setupToolbar() {
         binding.btnBack.setOnClickListener { findNavController().navigateUp() }
+        binding.imageSettings.setOnClickListener {
+            findNavController().navigate(R.id.action_global_settingsFragment)
+        }
     }
 
     private fun setupButton() {

--- a/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/main/HomeFragment.kt
+++ b/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/main/HomeFragment.kt
@@ -84,6 +84,10 @@ class HomeFragment : Fragment() {
     }
 
     private fun setupClickListeners() {
+        binding.imageSettings.setOnClickListener {
+            findNavController().navigate(R.id.action_global_settingsFragment)
+        }
+
         binding.continueLesson.setOnClickListener {
             val navController = findNavController()
             val lessonProgress = LessonProgressPreferences.getCurrentLesson(requireContext())

--- a/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/progress/ProgressFragment.kt
+++ b/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/progress/ProgressFragment.kt
@@ -62,6 +62,9 @@ class ProgressFragment : Fragment() {
         binding.btnBack.setOnClickListener {
             findNavController().navigateUp()
         }
+        binding.imageSettings.setOnClickListener {
+            findNavController().navigate(R.id.action_global_settingsFragment)
+        }
     }
 
     private fun setupSkillList() {

--- a/app/src/main/res/layout/fragment_article.xml
+++ b/app/src/main/res/layout/fragment_article.xml
@@ -29,10 +29,15 @@
                 android:textSize="20sp" />
 
             <ImageView
+                android:id="@+id/imageSettings"
                 android:layout_width="50dp"
                 android:layout_height="50dp"
                 android:layout_gravity="end"
                 android:layout_marginEnd="20dp"
+                android:background="?attr/selectableItemBackgroundBorderless"
+                android:clickable="true"
+                android:contentDescription="@string/settings_title"
+                android:focusable="true"
                 android:src="@drawable/settings_bg" />
 
             <TextView

--- a/app/src/main/res/layout/fragment_article_detail.xml
+++ b/app/src/main/res/layout/fragment_article_detail.xml
@@ -27,11 +27,15 @@
                 android:textSize="20sp" />
 
             <ImageView
+                android:id="@+id/imageSettings"
                 android:layout_width="50dp"
                 android:layout_height="50dp"
                 android:layout_gravity="end"
                 android:layout_marginEnd="20dp"
-                android:contentDescription="@null"
+                android:background="?attr/selectableItemBackgroundBorderless"
+                android:clickable="true"
+                android:contentDescription="@string/settings_title"
+                android:focusable="true"
                 android:src="@drawable/settings_bg" />
 
             <TextView

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -45,10 +45,14 @@
 
 
             <ImageView
+                android:id="@+id/imageSettings"
                 android:layout_width="60dp"
                 android:layout_height="53dp"
                 android:layout_gravity="center"
-                android:contentDescription="@null"
+                android:background="?attr/selectableItemBackgroundBorderless"
+                android:clickable="true"
+                android:contentDescription="@string/settings_title"
+                android:focusable="true"
                 android:src="@drawable/settings_bg" />
 
         </LinearLayout>

--- a/app/src/main/res/layout/fragment_lesson_detail.xml
+++ b/app/src/main/res/layout/fragment_lesson_detail.xml
@@ -30,11 +30,15 @@
                 android:textSize="20sp" />
 
             <ImageView
+                android:id="@+id/imageSettings"
                 android:layout_width="50dp"
-                android:layout_marginTop="10dp"
                 android:layout_height="50dp"
                 android:layout_gravity="end"
-                android:contentDescription="@null"
+                android:layout_marginTop="10dp"
+                android:background="?attr/selectableItemBackgroundBorderless"
+                android:clickable="true"
+                android:contentDescription="@string/settings_title"
+                android:focusable="true"
                 android:src="@drawable/settings_bg" />
 
         </FrameLayout>

--- a/app/src/main/res/layout/fragment_lesson_list.xml
+++ b/app/src/main/res/layout/fragment_lesson_list.xml
@@ -46,10 +46,15 @@
                 android:background="#00FFFFFF">
 
                 <ImageView
+                    android:id="@+id/imageSettings"
                     android:layout_width="60dp"
                     android:layout_height="53dp"
                     android:layout_gravity="end"
+                    android:background="?attr/selectableItemBackgroundBorderless"
+                    android:clickable="true"
+                    android:contentDescription="@string/settings_title"
                     android:elevation="1dp"
+                    android:focusable="true"
                     android:src="@drawable/settings_bg" />
 
                 <View

--- a/app/src/main/res/layout/fragment_lesson_step_detail.xml
+++ b/app/src/main/res/layout/fragment_lesson_step_detail.xml
@@ -30,11 +30,15 @@
                 android:textSize="20sp" />
 
             <ImageView
+                android:id="@+id/imageSettings"
                 android:layout_width="50dp"
                 android:layout_height="50dp"
                 android:layout_gravity="end"
                 android:layout_marginTop="10dp"
-                android:contentDescription="@null"
+                android:background="?attr/selectableItemBackgroundBorderless"
+                android:clickable="true"
+                android:contentDescription="@string/settings_title"
+                android:focusable="true"
                 android:src="@drawable/settings_bg" />
 
         </FrameLayout>

--- a/app/src/main/res/layout/fragment_progress.xml
+++ b/app/src/main/res/layout/fragment_progress.xml
@@ -44,10 +44,15 @@
                     android:background="#00FFFFFF">
 
                     <ImageView
+                        android:id="@+id/imageSettings"
                         android:layout_width="60dp"
                         android:layout_height="53dp"
                         android:layout_gravity="end"
+                        android:background="?attr/selectableItemBackgroundBorderless"
+                        android:clickable="true"
+                        android:contentDescription="@string/settings_title"
                         android:elevation="1dp"
+                        android:focusable="true"
                         android:src="@drawable/settings_bg" />
 
                     <View

--- a/app/src/main/res/layout/fragment_victory_hall.xml
+++ b/app/src/main/res/layout/fragment_victory_hall.xml
@@ -58,10 +58,15 @@
                         android:background="#00FFFFFF">
 
                         <ImageView
+                            android:id="@+id/imageSettings"
                             android:layout_width="60dp"
                             android:layout_height="53dp"
                             android:layout_gravity="end"
+                            android:background="?attr/selectableItemBackgroundBorderless"
+                            android:clickable="true"
+                            android:contentDescription="@string/settings_title"
                             android:elevation="1dp"
+                            android:focusable="true"
                             android:src="@drawable/settings_bg" />
 
                         <View

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -5,6 +5,10 @@
     android:id="@+id/nav_graph"
     app:startDestination="@id/splashFragment">
 
+    <action
+        android:id="@+id/action_global_settingsFragment"
+        app:destination="@id/settingsFragment" />
+
     <fragment
         android:id="@+id/splashFragment"
         android:name="sr.otaryp.tesatyla.presentation.ui.splash.SplashFragment"


### PR DESCRIPTION
## Summary
- add a global navigation action for the settings screen
- make the header settings icons clickable across home, lesson, article, progress, and victory hall fragments
- ensure the toolbar settings icons navigate to `SettingsFragment`

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e139c4dbbc832aa888b683fedca782