### PR TITLE
Animate circular focus timer indicator

### DIFF
--- a/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/custom/CircularProgressBar.kt
+++ b/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/custom/CircularProgressBar.kt
@@ -4,76 +4,140 @@ import android.animation.ValueAnimator
 import android.content.Context
 import android.graphics.Canvas
 import android.graphics.Color
+import android.graphics.Matrix
 import android.graphics.Paint
-import android.graphics.RadialGradient
-import android.graphics.Shader
+import android.graphics.SweepGradient
 import android.util.AttributeSet
 import android.view.View
+import android.view.animation.LinearInterpolator
 
 class CircularProgressBar @JvmOverloads constructor(
     context: Context,
-    attrs: AttributeSet? = null
+    attrs: AttributeSet? = null,
 ) : View(context, attrs) {
 
-    private val backgroundPaint: Paint = Paint()
-    private val progressPaint: Paint = Paint()
-    private var progress: Float = 0f // Start with 0% progress
-    private val strokeWidth: Int = 20 // Set stroke width
+    private val backgroundPaint = Paint(Paint.ANTI_ALIAS_FLAG)
+    private val progressPaint = Paint(Paint.ANTI_ALIAS_FLAG)
+    private var progress: Float = 0f
+    private val strokeWidth: Int = 20
     private var radius: Float = 0f
+    private val maxProgress = 100f
+
+    private var currentStartAngle = -90f
+    private var staticStartAngle: Float? = null
+    private val spinSweepAngle = 270f
+    private var isIndeterminate = false
+    private val gradientMatrix = Matrix()
+    private var progressShader: SweepGradient? = null
+
+    private val rotationAnimator: ValueAnimator = ValueAnimator.ofFloat(0f, 360f).apply {
+        duration = 1_500L
+        interpolator = LinearInterpolator()
+        repeatCount = ValueAnimator.INFINITE
+        addUpdateListener { animator ->
+            currentStartAngle = (animator.animatedValue as Float) - 90f
+            staticStartAngle = currentStartAngle
+            invalidate()
+        }
+    }
 
     init {
-        // Paint for background circle (inactive portion)
         backgroundPaint.apply {
-            color = Color.parseColor("#E0E0E0")
+            color = Color.TRANSPARENT
             style = Paint.Style.STROKE
             strokeWidth = this@CircularProgressBar.strokeWidth.toFloat()
-            isAntiAlias = true
         }
 
-        // Paint for progress circle (active portion)
         progressPaint.apply {
             style = Paint.Style.STROKE
             strokeWidth = this@CircularProgressBar.strokeWidth.toFloat()
-            isAntiAlias = true
+            strokeCap = Paint.Cap.ROUND
         }
-
-        // Apply gradient to progress paint
-        val gradient = RadialGradient(0f, 0f, radius, Color.parseColor("#1A7F7F"), Color.parseColor("#009999"), Shader.TileMode.CLAMP)
-        progressPaint.shader = gradient
-
-        // Animate progress (example)
-        val animator = ValueAnimator.ofFloat(0f, 360f) // Animate from 0% to 100%
-        animator.duration = 2000 // Duration of animation (2 seconds)
-        animator.addUpdateListener {
-            progress = it.animatedValue as Float
-            invalidate() // Redraw view to show progress update
-        }
-        animator.start()
     }
 
     override fun onSizeChanged(w: Int, h: Int, oldw: Int, oldh: Int) {
         super.onSizeChanged(w, h, oldw, oldh)
-        radius = (Math.min(w, h) / 2f) - strokeWidth // Set radius based on view size
+        radius = (minOf(w, h) / 2f) - strokeWidth
+
+        progressShader = SweepGradient(
+            w / 2f,
+            h / 2f,
+            intArrayOf(Color.parseColor("#1A7F7F"), Color.parseColor("#009999")),
+            floatArrayOf(0f, 1f),
+        ).also(progressPaint::setShader)
     }
 
     override fun onDraw(canvas: Canvas) {
         super.onDraw(canvas)
 
-        // Draw background circle
-        canvas.drawCircle(width / 2f, height / 2f, radius, backgroundPaint)
+        if (backgroundPaint.color != Color.TRANSPARENT) {
+            canvas.drawCircle(width / 2f, height / 2f, radius, backgroundPaint)
+        }
 
-        // Draw progress circle (animated)
-        val angle = (360 * progress) / 100
+        val startAngle = when {
+            isIndeterminate -> currentStartAngle
+            staticStartAngle != null -> staticStartAngle!!
+            else -> -90f
+        }
+
+        val sweepAngle = when {
+            isIndeterminate || staticStartAngle != null -> spinSweepAngle
+            else -> (360f * progress) / maxProgress
+        }
+
+        progressShader?.let { shader ->
+            gradientMatrix.reset()
+            gradientMatrix.postRotate(startAngle + 90f, width / 2f, height / 2f)
+            shader.setLocalMatrix(gradientMatrix)
+        }
+
         canvas.drawArc(
-            strokeWidth.toFloat(), strokeWidth.toFloat(),
-            (width - strokeWidth).toFloat(), (height - strokeWidth).toFloat(),
-            -90f, angle, false, progressPaint
-        ) // -90 to start the arc from the top
+            strokeWidth.toFloat(),
+            strokeWidth.toFloat(),
+            (width - strokeWidth).toFloat(),
+            (height - strokeWidth).toFloat(),
+            startAngle,
+            sweepAngle,
+            false,
+            progressPaint,
+        )
     }
 
-    // Method to update progress dynamically
     fun setProgress(progress: Float) {
-        this.progress = progress
-        invalidate() // Redraw the view with updated progress
+        this.progress = progress.coerceIn(0f, maxProgress)
+        staticStartAngle = null
+        invalidate()
+    }
+
+    fun startIndeterminateAnimation() {
+        if (isIndeterminate) return
+        isIndeterminate = true
+        rotationAnimator.start()
+    }
+
+    fun stopIndeterminateAnimation(resetToStart: Boolean = false) {
+        if (!isIndeterminate && !rotationAnimator.isRunning) {
+            if (resetToStart) {
+                staticStartAngle = null
+                currentStartAngle = -90f
+                invalidate()
+            }
+            return
+        }
+
+        rotationAnimator.cancel()
+        isIndeterminate = false
+
+        if (resetToStart) {
+            staticStartAngle = null
+            currentStartAngle = -90f
+        }
+
+        invalidate()
+    }
+
+    override fun onDetachedFromWindow() {
+        rotationAnimator.cancel()
+        super.onDetachedFromWindow()
     }
 }

--- a/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/focus/FocusFragment.kt
+++ b/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/focus/FocusFragment.kt
@@ -47,9 +47,11 @@ class FocusFragment : Fragment() {
     }
 
     override fun onDestroyView() {
-        super.onDestroyView()
+        binding.circularProgressBar.stopIndeterminateAnimation(resetToStart = true)
         countDownTimer?.cancel()
+        countDownTimer = null
         _binding = null
+        super.onDestroyView()
     }
 
     private fun setupUi() {
@@ -88,12 +90,14 @@ class FocusFragment : Fragment() {
         }.also { it.start() }
 
         isTimerRunning = true
+        binding.circularProgressBar.startIndeterminateAnimation()
     }
 
     private fun pauseTimer() {
         countDownTimer?.cancel()
         countDownTimer = null
         isTimerRunning = false
+        binding.circularProgressBar.stopIndeterminateAnimation()
     }
 
     private fun resetTimer() {
@@ -102,6 +106,7 @@ class FocusFragment : Fragment() {
         remainingMillis = FOCUS_DURATION_MILLIS
         updateSessionLabels()
         updateTimerUi()
+        binding.circularProgressBar.stopIndeterminateAnimation(resetToStart = true)
     }
 
     private fun handleTimerFinished() {
@@ -126,6 +131,7 @@ class FocusFragment : Fragment() {
             remainingMillis = FOCUS_DURATION_MILLIS
             updateSessionLabels()
             updateTimerUi()
+            binding.circularProgressBar.stopIndeterminateAnimation()
         }
     }
 
@@ -150,15 +156,6 @@ class FocusFragment : Fragment() {
 
     private fun updateTimerUi() {
         binding.timerTv.text = formatTime(remainingMillis)
-        val duration = if (isFocusSession) FOCUS_DURATION_MILLIS else BREAK_DURATION_MILLIS
-        val progress = if (duration == 0L) 0 else {
-            val elapsed = duration - remainingMillis
-            ((elapsed.coerceAtLeast(0L).toFloat() / duration) * PROGRESS_MAX)
-                .toInt()
-                .coerceIn(0, PROGRESS_MAX)
-        }
-//        binding.progressBar.setMax(PROGRESS_MAX)
-//        binding.progressBar.setProgress(progress)   // <<— используем кастомный метод
     }
 
 
@@ -171,7 +168,6 @@ class FocusFragment : Fragment() {
     companion object {
         private const val FOCUS_DURATION_MINUTES = 25
         private const val BREAK_DURATION_MINUTES = 5
-        private const val PROGRESS_MAX = 100
         private const val SECONDS_IN_MINUTE = 60
         private const val TICK_INTERVAL_MILLIS = 1_000L
 


### PR DESCRIPTION
## Summary
- animate the custom circular progress bar with an indeterminate rotating arc that can start, stop, or reset
- connect FocusFragment timer actions to start and stop the spinner so it turns while the timer runs and pauses when it stops

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e1579508fc832aae7f40390adaf32e