### PR TITLE
Animate circular progress indicator in ProgressFragment

### DIFF
--- a/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/progress/ProgressFragment.kt
+++ b/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/progress/ProgressFragment.kt
@@ -84,6 +84,7 @@ class ProgressFragment : Fragment() {
 
     private fun renderState(state: ProgressUiState) = with(binding) {
         textProgressPercentage.text = getString(R.string.progress_percentage_format, state.overallPercent)
+        circularProgressBar.animateProgress(state.overallPercent.toFloat())
 //        textLessonsCompleted.text = getString(
 //            R.string.progress_lessons_completed,
 //            state.completedSteps,


### PR DESCRIPTION
## Summary
- animate the custom circular progress bar to smoothly reach the provided percentage
- hook the progress fragment state observer to update the progress indicator alongside the percentage label

## Testing
- ./gradlew test *(fails: Android SDK not configured in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e1a4172f74832a9bf82e712d01109e