### PR TITLE
Add onboarding dots indicator for view pager

### DIFF
--- a/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/onboarding/OnBoardingFragment.kt
+++ b/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/onboarding/OnBoardingFragment.kt
@@ -4,25 +4,24 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-
+import androidx.appcompat.content.res.AppCompatResources
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.navOptions
-
-
 import androidx.viewpager2.widget.ViewPager2
+import com.google.android.material.tabs.TabLayoutMediator
 import sr.otaryp.tesatyla.R
 import sr.otaryp.tesatyla.data.preferences.LaunchPreferences
 import sr.otaryp.tesatyla.databinding.FragmentOnBoardingBinding
 import sr.otaryp.tesatyla.presentation.ui.lessons.applyVerticalGradient
-import kotlin.math.abs
 
 class OnBoardingFragment : Fragment() {
 
     private var _binding: FragmentOnBoardingBinding? = null
     private val binding get() = _binding!!
     private var pageChangeCallback: ViewPager2.OnPageChangeCallback? = null
+    private var tabMediator: TabLayoutMediator? = null
 
     private val slides by lazy {
         listOf(
@@ -56,7 +55,13 @@ class OnBoardingFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
 
         binding.viewPagerOnboarding.adapter = OnboardingPagerAdapter(slides)
-
+        binding.tabDotsOnboarding.tabIconTint = null
+        tabMediator = TabLayoutMediator(binding.tabDotsOnboarding, binding.viewPagerOnboarding) { tab, _ ->
+            tab.icon = AppCompatResources.getDrawable(requireContext(), R.drawable.onboarding_dot)
+        }.also { mediator ->
+            mediator.attach()
+        }
+        binding.tabDotsOnboarding.post { applyDotsSpacing() }
 
         updateEnterButtonVisibility(0)
 
@@ -88,10 +93,24 @@ class OnBoardingFragment : Fragment() {
         binding.btnEnterKingdom.isVisible = position == slides.lastIndex
     }
 
+    private fun applyDotsSpacing() {
+        val tabStrip = binding.tabDotsOnboarding.getChildAt(0) as? ViewGroup ?: return
+        val margin = resources.getDimensionPixelOffset(R.dimen.onboarding_indicator_margin)
+        for (index in 0 until tabStrip.childCount) {
+            val tabView = tabStrip.getChildAt(index)
+            val params = tabView.layoutParams as? ViewGroup.MarginLayoutParams ?: continue
+            params.marginStart = margin
+            params.marginEnd = margin
+            tabView.layoutParams = params
+        }
+    }
+
     override fun onDestroyView() {
         pageChangeCallback?.let { binding.viewPagerOnboarding.unregisterOnPageChangeCallback(it) }
         binding.viewPagerOnboarding.adapter = null
+        tabMediator?.detach()
         pageChangeCallback = null
+        tabMediator = null
         _binding = null
         super.onDestroyView()
     }

--- a/app/src/main/res/drawable/onboarding_dot.xml
+++ b/app/src/main/res/drawable/onboarding_dot.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_selected="true">
+        <shape android:shape="oval">
+            <size android:width="12dp" android:height="12dp" />
+            <solid android:color="#FFE08A" />
+        </shape>
+    </item>
+    <item>
+        <shape android:shape="oval">
+            <size android:width="8dp" android:height="8dp" />
+            <solid android:color="#40FFFFFF" />
+        </shape>
+    </item>
+</selector>

--- a/app/src/main/res/layout/fragment_on_boarding.xml
+++ b/app/src/main/res/layout/fragment_on_boarding.xml
@@ -37,12 +37,24 @@
                 tools:listitem="@layout/item_onboarding_slide" />
         </FrameLayout>
 
+        <com.google.android.material.tabs.TabLayout
+            android:id="@+id/tabDotsOnboarding"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="bottom|center_horizontal"
+            android:layout_marginBottom="88dp"
+            app:tabGravity="center"
+            app:tabIndicator="@android:color/transparent"
+            app:tabIndicatorFullWidth="false"
+            app:tabMode="fixed"
+            app:tabRippleColor="@android:color/transparent" />
+
         <androidx.appcompat.widget.AppCompatButton
             android:id="@+id/btnEnterKingdom"
             android:layout_width="wrap_content"
-            android:layout_marginEnd="20dp"
             android:layout_height="wrap_content"
             android:layout_gravity="bottom|end"
+            android:layout_marginEnd="20dp"
             android:background="@drawable/btn_enter_kingdom"
             android:includeFontPadding="false"
             android:letterSpacing="0.03"


### PR DESCRIPTION
## Summary
- add a TabLayout-based dots indicator to the onboarding ViewPager and keep it in sync with page changes
- style the indicator with custom drawable dots and spacing for a polished appearance

## Testing
- ./gradlew test *(fails: missing Android SDK in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e3ae6cf954832aa3c06f009b252e3b