### PR TITLE
Pass selected article image to article detail fragment

### DIFF
--- a/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/article/ArticleDetailFragment.kt
+++ b/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/article/ArticleDetailFragment.kt
@@ -29,6 +29,7 @@ class ArticleDetailFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
         binding.textArticleTitle.text = args.articleTitle
         binding.textArticleContent.text = args.articleContent
+        binding.imageArticleCover.setImageResource(args.articleImageRes)
         binding.btnBack.setOnClickListener { findNavController().popBackStack() }
         binding.imageSettings.setOnClickListener {
             findNavController().navigate(R.id.action_global_settingsFragment)

--- a/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/article/ArticleFragment.kt
+++ b/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/article/ArticleFragment.kt
@@ -96,7 +96,8 @@ class ArticleFragment : Fragment() {
         // Вариант с SafeArgs (как у тебя было ранее)
         val directions = ArticleFragmentDirections.actionNavArticlesToArticleDetailFragment(
             articleTitle = article.title,
-            articleContent = article.content
+            articleContent = article.content,
+            articleImageRes = InspirationRepository.imageFor(article.id)
         )
         findNavController().navigate(directions)
 

--- a/app/src/main/res/layout/fragment_article_detail.xml
+++ b/app/src/main/res/layout/fragment_article_detail.xml
@@ -79,12 +79,13 @@
                 android:src="@drawable/list_shorter" />
 
             <ImageView
+                android:id="@+id/imageArticleCover"
                 android:layout_width="200dp"
                 android:layout_height="200dp"
                 android:layout_gravity="center|bottom"
                 android:layout_marginStart="5dp"
                 android:contentDescription="@null"
-                android:src="@drawable/article_im1" />
+                tools:src="@drawable/article_im1" />
 
         </FrameLayout>
 

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -158,6 +158,10 @@
         <argument
             android:name="articleContent"
             app:argType="string" />
+        <argument
+            android:name="articleImageRes"
+            app:argType="reference"
+            android:defaultValue="@drawable/article_im1" />
     </fragment>
 
     <fragment


### PR DESCRIPTION
## Summary
- add a Safe Args parameter to pass the selected article's image resource to the detail screen
- update the detail layout and fragment to render the provided cover image
- send the corresponding image resource from the article list when navigating to the detail

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e3b183d31c832a88d82a48763546e1