### PR TITLE
Fix system back navigation to previous screens

### DIFF
--- a/app/src/main/java/sr/otaryp/tesatyla/MainActivity.kt
+++ b/app/src/main/java/sr/otaryp/tesatyla/MainActivity.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.view.View
 import android.widget.TextView
 import androidx.activity.enableEdgeToEdge
+import androidx.activity.addCallback
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
@@ -13,9 +14,24 @@ import androidx.navigation.NavOptions
 import androidx.navigation.fragment.NavHostFragment
 import sr.otaryp.tesatyla.presentation.ui.lessons.applyVerticalGradient
 import sr.otaryp.tesatyla.presentation.ui.setupCustomBottomNav
+import sr.otaryp.tesatyla.presentation.ui.setSelectedIndex
 
 class MainActivity : AppCompatActivity() {
     private lateinit var navController: NavController
+    private val destinationsWithBottomNav = setOf(
+        R.id.nav_home,
+        R.id.nav_lessons,
+        R.id.nav_articles,
+        R.id.nav_progress,
+        R.id.nav_focus
+    )
+    private val destinationToNavIndex = mapOf(
+        R.id.nav_home to 0,
+        R.id.nav_lessons to 1,
+        R.id.nav_articles to 2,
+        R.id.nav_progress to 3,
+        R.id.nav_focus to 4
+    )
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -33,18 +49,17 @@ class MainActivity : AppCompatActivity() {
             .findFragmentById(R.id.nav_host_fragment) as NavHostFragment
         navController = navHostFragment.navController
 
-        val destinationsWithBottomNav = setOf(
-            R.id.nav_home,
-            R.id.nav_lessons,
-            R.id.nav_articles,
-            R.id.nav_progress,
-            R.id.nav_focus
-        )
+        onBackPressedDispatcher.addCallback(this) {
+            handleOnBackPressed()
+        }
 
         val bottomNav = findViewById<View>(R.id.bottomBar)
 
         navController.addOnDestinationChangedListener { _, destination, _ ->
             bottomNav?.isVisible = destination.id in destinationsWithBottomNav
+            destinationToNavIndex[destination.id]?.let { index ->
+                bottomNav?.setSelectedIndex(index)
+            }
         }
 
         bottomNav?.let { view ->
@@ -80,5 +95,20 @@ class MainActivity : AppCompatActivity() {
             .build()
 
         navController.navigate(destinationId, null, navOptions)
+    }
+
+    private fun handleOnBackPressed() {
+        if (!::navController.isInitialized) {
+            finish()
+            return
+        }
+
+        val currentDestinationId = navController.currentDestination?.id
+
+        when {
+            navController.previousBackStackEntry != null -> navController.popBackStack()
+            currentDestinationId == R.id.nav_home -> finish()
+            else -> openHome()
+        }
     }
 }


### PR DESCRIPTION
## Summary
- intercept the system back button to pop the navigation stack or return to the home tab before exiting
- keep the custom bottom navigation selection in sync with the active destination

## Testing
- ./gradlew lint *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e3ca3473e0832ab0451caa976bb5aa