### PR TITLE
Ensure back button returns to Home from other tabs

### DIFF
--- a/app/src/main/java/sr/otaryp/tesatyla/MainActivity.kt
+++ b/app/src/main/java/sr/otaryp/tesatyla/MainActivity.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.view.View
 import android.widget.TextView
 import androidx.activity.enableEdgeToEdge
+import androidx.activity.addCallback
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
@@ -13,9 +14,24 @@ import androidx.navigation.NavOptions
 import androidx.navigation.fragment.NavHostFragment
 import sr.otaryp.tesatyla.presentation.ui.lessons.applyVerticalGradient
 import sr.otaryp.tesatyla.presentation.ui.setupCustomBottomNav
+import sr.otaryp.tesatyla.presentation.ui.setSelectedIndex
 
 class MainActivity : AppCompatActivity() {
     private lateinit var navController: NavController
+    private val destinationsWithBottomNav = setOf(
+        R.id.nav_home,
+        R.id.nav_lessons,
+        R.id.nav_articles,
+        R.id.nav_progress,
+        R.id.nav_focus
+    )
+    private val destinationToNavIndex = mapOf(
+        R.id.nav_home to 0,
+        R.id.nav_lessons to 1,
+        R.id.nav_articles to 2,
+        R.id.nav_progress to 3,
+        R.id.nav_focus to 4
+    )
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -33,18 +49,17 @@ class MainActivity : AppCompatActivity() {
             .findFragmentById(R.id.nav_host_fragment) as NavHostFragment
         navController = navHostFragment.navController
 
-        val destinationsWithBottomNav = setOf(
-            R.id.nav_home,
-            R.id.nav_lessons,
-            R.id.nav_articles,
-            R.id.nav_progress,
-            R.id.nav_focus
-        )
+        onBackPressedDispatcher.addCallback(this) {
+            handleOnBackPressed()
+        }
 
         val bottomNav = findViewById<View>(R.id.bottomBar)
 
         navController.addOnDestinationChangedListener { _, destination, _ ->
             bottomNav?.isVisible = destination.id in destinationsWithBottomNav
+            destinationToNavIndex[destination.id]?.let { index ->
+                bottomNav?.setSelectedIndex(index)
+            }
         }
 
         bottomNav?.let { view ->
@@ -76,9 +91,38 @@ class MainActivity : AppCompatActivity() {
 
         val navOptions = NavOptions.Builder()
             .setLaunchSingleTop(true)
-            .setPopUpTo(R.id.nav_graph, false)
+            .setPopUpTo(navController.currentDestination?.id ?: destinationId, true)
             .build()
 
         navController.navigate(destinationId, null, navOptions)
+    }
+
+    private fun handleOnBackPressed() {
+        if (!::navController.isInitialized) {
+            finish()
+            return
+        }
+
+        if (navController.popBackStack()) {
+            return
+        }
+
+        val currentDestinationId = navController.currentDestination?.id ?: run {
+            finish()
+            return
+        }
+
+        if (currentDestinationId in destinationsWithBottomNav && currentDestinationId != R.id.nav_home) {
+            if (!navController.popBackStack(R.id.nav_home, false)) {
+                val navOptions = NavOptions.Builder()
+                    .setLaunchSingleTop(true)
+                    .setPopUpTo(currentDestinationId, true)
+                    .build()
+                navController.navigate(R.id.nav_home, null, navOptions)
+            }
+            return
+        }
+
+        finish()
     }
 }


### PR DESCRIPTION
## Summary
- replace bottom navigation tab switches so the current destination is removed before navigating to the requested tab
- update back press handling to pop the stack, return to the Home tab when on other bottom navigation roots, and only exit from Home

## Testing
- ./gradlew lint *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e3ca3473e0832ab0451caa976bb5aa