### PR TITLE
Handle back navigation in feature fragments

### DIFF
--- a/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/article/ArticleFragment.kt
+++ b/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/article/ArticleFragment.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.activity.addCallback
 import androidx.core.view.isVisible
 import androidx.core.widget.doAfterTextChanged
 import androidx.fragment.app.Fragment
@@ -37,6 +38,7 @@ class ArticleFragment : Fragment() {
         setupSearchBar()
         setupBackButton()
         setupSettingsButton()
+        setupSystemBackNavigation()
 
         // стартовый список
         showArticles(allArticles)
@@ -74,9 +76,13 @@ class ArticleFragment : Fragment() {
 
     private fun setupBackButton() {
         binding.btnBack.setOnClickListener {
-            // если экран живёт в нижней навигации — можно вернуть на home
-            // findNavController().navigate(R.id.nav_home)
-            findNavController().navigateUp()
+            navigateHome()
+        }
+    }
+
+    private fun setupSystemBackNavigation() {
+        requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner) {
+            navigateHome()
         }
     }
 
@@ -104,6 +110,13 @@ class ArticleFragment : Fragment() {
         // Если нужен переход по ID, раскомментируй этот вариант и поправь граф:
 //         val action = ArticleFragmentDirections.actionArticleFragmentToArticleDetailFragment(article.id)
 //         findNavController().navigate(action)
+    }
+
+    private fun navigateHome() {
+        val navController = findNavController()
+        if (!navController.popBackStack(R.id.nav_home, false)) {
+            navController.navigate(R.id.nav_home)
+        }
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/focus/FocusFragment.kt
+++ b/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/focus/FocusFragment.kt
@@ -6,6 +6,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
+import androidx.activity.addCallback
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
 import java.util.Locale
@@ -40,6 +41,7 @@ class FocusFragment : Fragment() {
         setupUi()
         setupListeners()
         setupBackNavigation()
+        setupSystemBackNavigation()
 
         binding.timerTv.applyVerticalGradient()
         binding.titleTv.applyVerticalGradient()
@@ -70,7 +72,13 @@ class FocusFragment : Fragment() {
 
     private fun setupBackNavigation() {
         binding.btnBack.setOnClickListener {
-            findNavController().navigateUp()
+            navigateHome()
+        }
+    }
+
+    private fun setupSystemBackNavigation() {
+        requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner) {
+            navigateHome()
         }
     }
 
@@ -174,6 +182,13 @@ class FocusFragment : Fragment() {
         val minutes = TimeUnit.MILLISECONDS.toMinutes(millis)
         val seconds = TimeUnit.MILLISECONDS.toSeconds(millis) % SECONDS_IN_MINUTE
         return String.format(Locale.getDefault(), "%02d:%02d", minutes, seconds)
+    }
+
+    private fun navigateHome() {
+        val navController = findNavController()
+        if (!navController.popBackStack(R.id.nav_home, false)) {
+            navController.navigate(R.id.nav_home)
+        }
     }
 
     companion object {

--- a/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/lessons/LessonListFragment.kt
+++ b/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/lessons/LessonListFragment.kt
@@ -8,6 +8,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
+import androidx.activity.addCallback
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
@@ -53,6 +54,7 @@ class LessonListFragment : Fragment() {
         setupRecyclerView()
         observeLessons()
         applyVerticalGradient(binding.tvTitle)
+        setupSystemBackNavigation()
     }
     private fun applyVerticalGradient(tv: TextView) {
         tv.addOnLayoutChangeListener(object : View.OnLayoutChangeListener {
@@ -81,11 +83,17 @@ class LessonListFragment : Fragment() {
 
     private fun setupToolbar() {
         binding.btnBack.setOnClickListener {
-            findNavController().navigateUp()
+            navigateHome()
         }
         val skill = SkillCatalog.findSkill(args.skillId)
         binding.imageSettings.setOnClickListener {
             findNavController().navigate(R.id.action_global_settingsFragment)
+        }
+    }
+
+    private fun setupSystemBackNavigation() {
+        requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner) {
+            navigateHome()
         }
     }
 
@@ -122,5 +130,12 @@ class LessonListFragment : Fragment() {
         val directions = LessonListFragmentDirections
             .actionNavLessonsToLessonDetailFragment(lesson.id)
         findNavController().navigate(directions)
+    }
+
+    private fun navigateHome() {
+        val navController = findNavController()
+        if (!navController.popBackStack(R.id.nav_home, false)) {
+            navController.navigate(R.id.nav_home)
+        }
     }
 }

--- a/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/progress/ProgressFragment.kt
+++ b/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/progress/ProgressFragment.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.activity.addCallback
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
@@ -40,6 +41,7 @@ class ProgressFragment : Fragment() {
         setupToolbar()
         setupSkillList()
         observeState()
+        setupSystemBackNavigation()
 
         binding.pomodoroCycles.applyVerticalGradient()
         binding.skillMasteryTitle.applyVerticalGradient()
@@ -60,10 +62,16 @@ class ProgressFragment : Fragment() {
 
     private fun setupToolbar() {
         binding.btnBack.setOnClickListener {
-            findNavController().navigateUp()
+            navigateHome()
         }
         binding.imageSettings.setOnClickListener {
             findNavController().navigate(R.id.action_global_settingsFragment)
+        }
+    }
+
+    private fun setupSystemBackNavigation() {
+        requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner) {
+            navigateHome()
         }
     }
 
@@ -101,5 +109,12 @@ class ProgressFragment : Fragment() {
         val directions = ProgressFragmentDirections
             .actionNavProgressToNavLessons(item.id)
         findNavController().navigate(directions)
+    }
+
+    private fun navigateHome() {
+        val navController = findNavController()
+        if (!navController.popBackStack(R.id.nav_home, false)) {
+            navController.navigate(R.id.nav_home)
+        }
     }
 }


### PR DESCRIPTION
## Summary
- ensure the article, lessons, focus, and progress screens handle the system back press by returning to Home
- reuse the same helper for UI back buttons so both hardware and software back navigation behave consistently
- fall back to navigating to Home when it is not already on the back stack

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e3d9f90e4c832a9cc8784f808404e1