### PR TITLE
Ensure clearing data resets progress without removing lessons

### DIFF
--- a/app/src/main/java/sr/otaryp/tesatyla/data/lessons/LessonDao.kt
+++ b/app/src/main/java/sr/otaryp/tesatyla/data/lessons/LessonDao.kt
@@ -36,6 +36,12 @@ interface LessonDao {
     @Query("UPDATE lessons SET isCompleted = :isCompleted WHERE id = :lessonId")
     suspend fun updateLessonCompletion(lessonId: Int, isCompleted: Boolean)
 
+    @Query("UPDATE lesson_steps SET isCompleted = 0")
+    suspend fun resetAllSteps()
+
+    @Query("UPDATE lessons SET isCompleted = 0")
+    suspend fun resetAllLessons()
+
     @Query("SELECT COUNT(*) FROM lessons")
     suspend fun countLessons(): Int
 

--- a/app/src/main/java/sr/otaryp/tesatyla/data/lessons/LessonRepository.kt
+++ b/app/src/main/java/sr/otaryp/tesatyla/data/lessons/LessonRepository.kt
@@ -59,6 +59,13 @@ class LessonRepository private constructor(
         lessonDao.updateLessonCompletion(lessonId, false)
     }
 
+    suspend fun resetAllProgress() {
+        prepopulateJob.await()
+
+        lessonDao.resetAllSteps()
+        lessonDao.resetAllLessons()
+    }
+
     suspend fun getNextIncompleteStep(lessonId: Int): LessonStepEntity? {
         prepopulateJob.await()
         return lessonDao.getNextIncompleteStep(lessonId)

--- a/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/settings/SettingsFragment.kt
+++ b/app/src/main/java/sr/otaryp/tesatyla/presentation/ui/settings/SettingsFragment.kt
@@ -17,7 +17,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import sr.otaryp.tesatyla.R
-import sr.otaryp.tesatyla.data.lessons.LessonDatabase
+import sr.otaryp.tesatyla.data.lessons.LessonRepository
 import sr.otaryp.tesatyla.data.preferences.FocusPreferences
 import sr.otaryp.tesatyla.data.preferences.LaunchPreferences
 import sr.otaryp.tesatyla.data.preferences.LessonProgressPreferences
@@ -104,9 +104,10 @@ class SettingsFragment : Fragment() {
 
     private fun clearAppData() {
         val appContext = requireContext().applicationContext
+        val repository = LessonRepository.getInstance(appContext)
         viewLifecycleOwner.lifecycleScope.launch {
             withContext(Dispatchers.IO) {
-                LessonDatabase.getInstance(appContext).clearAllTables()
+                repository.resetAllProgress()
                 clearPreferences(appContext)
             }
             Toast.makeText(requireContext(), R.string.settings_clear_data_success, Toast.LENGTH_SHORT).show()


### PR DESCRIPTION
## Summary
- reset lesson and step completion flags through the repository instead of dropping the entire lesson database
- add DAO helpers so clearing data preserves lesson content while removing completion state

## Testing
- ./gradlew test *(fails: Android SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e519228754832ab39c465fdc5b6979